### PR TITLE
Fix for concurrency bug in python library, and corresponding test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.pyc
+build/
+dist/
+*.egg-info/

--- a/languages/python/atom/element.py
+++ b/languages/python/atom/element.py
@@ -1,4 +1,5 @@
 import redis
+import threading
 from atom.config import DEFAULT_REDIS_PORT, DEFAULT_REDIS_SOCKET
 from atom.config import LANG, VERSION, ACK_TIMEOUT, RESPONSE_TIMEOUT, STREAM_LEN, MAX_BLOCK
 from atom.config import ATOM_NO_ERROR, ATOM_COMMAND_NO_ACK, ATOM_COMMAND_NO_RESPONSE
@@ -25,12 +26,14 @@ class Element:
         self.timeouts = {}
         self.streams = set()
         self._rclient = None
+        self._command_loop_shutdown = threading.Event()
         try:
             if host is not None:
                 self._rclient = redis.StrictRedis(host=host, port=port)
             else:
                 self._rclient = redis.StrictRedis(unix_socket_path=socket_path)
             self._pipe = self._rclient.pipeline()
+            self._write_pipe = self._rclient.pipeline()
             self._pipe.xadd(
                 self._make_response_id(self.name),
                 maxlen=STREAM_LEN,
@@ -206,7 +209,7 @@ class Element:
         Sends acknowledge to caller and then runs command.
         Returns response with processed data to caller.
         """
-        while True:
+        while not self._command_loop_shutdown.isSet():
             # Get oldest new command from element's command stream
             stream = {self._make_command_id(self.name): self.command_last_id}
             cmd_response = self._rclient.xread(block=MAX_BLOCK, count=1, **stream)
@@ -262,6 +265,10 @@ class Element:
             self._pipe.xadd(self._make_response_id(caller), maxlen=STREAM_LEN, **vars(response))
             self._pipe.execute()
 
+    # Triggers graceful exit of command loop
+    def command_loop_shutdown(self):
+        self._command_loop_shutdown.set()
+
     def command_send(self,
                      element_name,
                      cmd_name,
@@ -287,8 +294,8 @@ class Element:
         # Send command to element's command stream
         data = packb(data, use_bin_type=True) if serialize and (data != "") else data
         cmd = Cmd(self.name, cmd_name, data)
-        self._pipe.xadd(self._make_command_id(element_name), maxlen=STREAM_LEN, **vars(cmd))
-        cmd_id = self._pipe.execute()[-1].decode()
+        self._write_pipe.xadd(self._make_command_id(element_name), maxlen=STREAM_LEN, **vars(cmd))
+        cmd_id = self._write_pipe.execute()[-1].decode()
         timeout = None
 
         # Receive acknowledge from element
@@ -444,8 +451,8 @@ class Element:
             for k, v in field_data_map.items():
                 field_data_map[k] = packb(v, use_bin_type=True)
         entry = Entry(field_data_map)
-        self._pipe.xadd(self._make_stream_id(self.name, stream_name), maxlen=maxlen, **vars(entry))
-        self._pipe.execute()
+        self._write_pipe.xadd(self._make_stream_id(self.name, stream_name), maxlen=maxlen, **vars(entry))
+        self._write_pipe.execute()
 
     def log(self, level, msg, stdout=True):
         """

--- a/languages/python/tests/test_atom.py
+++ b/languages/python/tests/test_atom.py
@@ -213,7 +213,49 @@ class TestAtom:
         entries = caller.entry_read_since("test_responder", "test_stream", last_id, 2)
         assert(len(entries) == 2)
         assert entries[-1]["data"] == b"1"
-        
+
+    def test_parallel_read_write(self, caller, responder):
+        """
+        Has the same responder class receiving commands on 1 thread,
+        while publishing to a stream on a 2nd thread at high volume.
+        Meanwhile, a caller quickly sends a series of commands to the responder and verifies
+        we get valid results back.
+        Ensures that we can safely send and receive using the same element class without concurrency issues.
+        """
+        responder_0 = Element("responder_0")
+        # NO_OP command responds with whatever data it receives
+        def no_op_serialized(data):
+            return Response(data, serialize=True)
+        responder_0.command_add("no_op", no_op_serialized, deserialize=True)
+
+        # Entry write loop mimics high volume publisher
+        def entry_write_loop(responder):
+            for i in range(3000):
+                responder.entry_write("stream_0", {"value": 0}, serialize=True)
+                time.sleep(0.0001)
+
+        # Command loop thread to handle incoming commands
+        command_loop_thread = Thread(target=responder_0.command_loop, daemon=True)
+        # Entry write thread to publish a whole bunch to a stream
+        entry_write_thread = Thread(target=entry_write_loop, args=(responder_0,), daemon=True)
+        command_loop_thread.start()
+        entry_write_thread.start()
+
+        # Send a bunch of commands to responder and you should get valid responses back,
+        # even while its busy publishing to a stream
+        try:
+            for i in range(20):
+                response = caller.command_send("responder_0", "no_op", 1, serialize=True, deserialize=True)
+                assert response["err_code"] == ATOM_NO_ERROR
+                assert response["data"] == 1
+        finally:
+            # Cleanup threads
+            entry_write_thread.join(0.5)
+            responder.command_loop_shutdown()
+            command_loop_thread.join(0.5)
+            responder_0._rclient.delete("stream:responder_0:stream_0")
+            responder_0._rclient.delete("command:responder_0:no_op")
+
     def test_no_ack(self, caller, responder):
         """
         Element sends command and responder does not acknowledge.
@@ -269,7 +311,7 @@ class TestAtom:
         logs = logs[-8:]
         for i in range(8):
             assert logs[i][1][b"msg"].decode() == f"severity {i}"
-            
+
 
 def add_1(x):
     return Response(int(x)+1)

--- a/languages/python/tests/test_atom.py
+++ b/languages/python/tests/test_atom.py
@@ -250,11 +250,12 @@ class TestAtom:
                 assert response["data"] == 1
         finally:
             # Cleanup threads
-            entry_write_thread.join(0.5)
+            entry_write_thread.join()
             responder.command_loop_shutdown()
             command_loop_thread.join(0.5)
             responder_0._rclient.delete("stream:responder_0:stream_0")
-            responder_0._rclient.delete("command:responder_0:no_op")
+            responder_0._rclient.delete("command:responder_0")
+            responder_0._rclient.delete("response:responder_0")
 
     def test_no_ack(self, caller, responder):
         """


### PR DESCRIPTION
Discovered a bug in the Element class, where we get redis client crashes if we try to publish at >5-10 hz to a stream on one thread, while running the command_loop and handling incoming commands on another thread. This is a paradigm we rely on in some of our other element repos, (for example: https://github.com/elementary-robotics/element-instance-segmentation/blob/master/run.py), but up till now we haven't been running them fast enough to hit this consistently. After some digging, I traced the problem to the use of a shared redis `_pipeline` inside the Element class. From the thread safety section of the pyredis docs: `It is not safe to pass PubSub or Pipeline objects between threads`: (https://github.com/andymccurdy/redis-py/blob/master/README.rst#thread-safety)

This PR addresses the issue by having the write functions use their own dedicated pipeline object instead of the one used for the command loop/reader calls. This seems like a good compromise for now, where we aren't slowing down the write/read calls with the use of mutexes, and also aren't requiring any api changes from any elements that depend on atom. I've included a unit test which validates this error case, you should see it fail when running the old version.

I've also modified the command_loop while condition to make it possible to trigger a shutdown using an Event, mostly as a convenience for the unit test, but also it doesn't hurt to have this capability.
