### PR TITLE
Python support for retrieving available commands of elements in atom-cli

### DIFF
--- a/languages/python/atom/config.py
+++ b/languages/python/atom/config.py
@@ -1,4 +1,4 @@
-VERSION = "0.2.0"
+VERSION = "0.3.0"
 
 LANG = "Python"
 ACK_TIMEOUT = 1000
@@ -11,6 +11,7 @@ REDIS_PIPELINE_POOL_SIZE = 20
 DEFAULT_REDIS_SOCKET = "/shared/redis.sock"
 HEALTHCHECK_COMMAND = "healthcheck"
 VERSION_COMMAND = "version"
+COMMAND_LIST_COMMAND = "command_list"
 
 # Error codes
 ATOM_NO_ERROR = 0

--- a/utilities/atom-cli/atom-cli.py
+++ b/utilities/atom-cli/atom-cli.py
@@ -44,12 +44,13 @@ class AtomCLI:
                   help [<command>]"""),
 
             "cmd_list": cleandoc("""
-                Displays available elements or streams.
-                Can filter streams based on element.
+                Displays available elements, streams, or commands.
+                Can filter streams and commands based on element.
 
                 Usage:
                   list elements
-                  list streams [<element>]"""),
+                  list streams [<element>]
+                  list commands [<element>]"""),
 
             "cmd_records": cleandoc("""
                 Displays log records or command and response records.
@@ -165,6 +166,7 @@ class AtomCLI:
         mode_map = {
             "elements": self.element.get_all_elements,
             "streams": self.element.get_all_streams,
+            "commands": self.element.get_all_commands
         }
         if not args:
             print(usage)
@@ -175,9 +177,9 @@ class AtomCLI:
             print(usage)
             print("\nInvalid argument to 'list'.")
             return
-        if len(args) > 1 and mode != "streams":
+        if len(args) > 1 and mode == "elements":
             print(usage)
-            print(f"\nInvalid number of arguments for command 'list {mode}'.")
+            print(f"\nInvalid number of arguments for command 'list elements'.")
             return
         if len(args) > 2:
             print(usage)


### PR DESCRIPTION
Support for #62 

Implements checking of available commands through atom-cli with the same front facing interface of "list streams". In atom-cli, "list commands" displays all available commands for all elements, while "list commands <element>" displays available commands for a single element. 

Retrieval of an element's commands uses a custom implemented command, similar to health and version checks, to prevent creating additional Redis structures. 

Retrieval of all commands at once is achieved by iterating through all existing Elements, sending a command to each. As a side-effect, for any Elements that do not have an active command loop, a failed to receive acknowledge is logged, as that Element will not be responding to commands. For the purpose of atom-cli, this is bypassed by not attempting to retrieve commands of the calling Element; however, if it's likely that other elements will have an inactive command loop, this implementation should be restructured. 

Two test cases have been created for testing both the custom command and the get all commands functionality. Additionally, in test_atom.py, pytest fixtures for yielding responders now explicitly invoke the garbage collector. Failing to do so while calling del on the element only de-increments the reference count of the object, and does not guarantee deletion in-between test cases (which causes inconsistent and rare test failures). Please let me know if this change should be a separate commit! 

