### PR TITLE
Added Version and Healthcheck support to C++ SDK

### DIFF
--- a/languages/c/src/element_command_send.c
+++ b/languages/c/src/element_command_send.c
@@ -20,7 +20,7 @@
 #include "atom.h"
 #include "element.h"
 
-#define ELEMENT_COMMAND_ACK_TIMEOUT 100000
+#define ELEMENT_COMMAND_ACK_TIMEOUT 1000
 
 // How long to wait for a response if the command is not supported
 #define ELEMENT_NO_COMMAND_TIMEOUT_MS 1000

--- a/languages/c/src/element_command_server.c
+++ b/languages/c/src/element_command_server.c
@@ -501,14 +501,14 @@ bool element_command_add(
 	struct element_command *cmd = NULL;
 	uint32_t hash;
 
-	cmd = element_command_get(elem, command);
-
 	// If command already exists, we should update it instead of allocating a new command
+	cmd = element_command_get(elem, command);
 	if (cmd != NULL) {
 		cmd->cb = cb;
 		cmd->cleanup = cleanup;
 		cmd->timeout = timeout;
 		cmd->user_data = user_data;
+		return true;
 	}
 
 	// Need to allocate the memory for the new command

--- a/languages/c/src/element_command_server.c
+++ b/languages/c/src/element_command_server.c
@@ -501,6 +501,16 @@ bool element_command_add(
 	struct element_command *cmd = NULL;
 	uint32_t hash;
 
+	cmd = element_command_get(elem, command);
+
+	// If command already exists, we should update it instead of allocating a new command
+	if (cmd != NULL) {
+		cmd->cb = cb;
+		cmd->cleanup = cleanup;
+		cmd->timeout = timeout;
+		cmd->user_data = user_data;
+	}
+
 	// Need to allocate the memory for the new command
 	cmd = malloc(sizeof(struct element_command));
 	assert(cmd != NULL);

--- a/languages/c/src/redis.c
+++ b/languages/c/src/redis.c
@@ -332,11 +332,9 @@ bool redis_xread(
 		goto done;
 	}
 
-	// Otherwise we have a reply. If we timed out then there are no
-	//	callbacks to call so we can just note that. This is an acceptable
-	//	outcome.
+	// If we timed out reply should be false
 	if (reply->type == REDIS_REPLY_NIL) {
-		ret_val = true;
+		ret_val = false;
 		goto free_reply;
 	}
 

--- a/languages/cpp/Makefile
+++ b/languages/cpp/Makefile
@@ -43,7 +43,7 @@ endif
 CFLAGS := -std=c++11 -Wall -Werror -fPIC -I${INCLUDE_DIR} -I${HIREDIS_BUILD_DIR}/include/ -g
 
 #LDFLAGS
-LDFLAGS := -L${HIREDIS_BUILD_DIR}/lib -Wl,-rpath,${HIREDIS_BUILD_DIR}/lib -latom -lhiredis -lpthread
+LDFLAGS := -L${HIREDIS_BUILD_DIR}/lib -Wl,-rpath,${HIREDIS_BUILD_DIR}/lib -latom -lhiredis -lpthread -lmsgpackc
 
 $(BUILD_DIR)/lib/%.o: src/%.cc $(HEADER_OBJS) | $(BUILD_DIR)/lib
 	@ echo "Compiling $<"

--- a/languages/cpp/inc/element.h
+++ b/languages/cpp/inc/element.h
@@ -27,6 +27,7 @@
 #include "command.h"
 
 #define ATOM_VERSION_CPP "v0.2.0"
+#define ATOM_LANGUAGE_CPP "c++"
 #define ATOM_VERSION_COMMAND "version"
 #define ATOM_HEALTHCHECK_COMMAND "healthcheck"
 #define ATOM_HEALTHCHECK_RETRY_INTERVAL_MS 5000

--- a/languages/cpp/inc/element.h
+++ b/languages/cpp/inc/element.h
@@ -164,7 +164,7 @@ class Element {
 	// Helper function for checking if another element meets version requirements
 	bool checkElementVersion(
 		std::string element,
-		std::set<std::string> supported_language_set,
+		std::set<std::string> &supported_language_set,
 		double supported_min_version);
 
 public:
@@ -180,7 +180,17 @@ public:
 	// Returns the name of the element
 	const std::string &getName();
 
-	void getElementVersion(ElementResponse &response, std::map<std::string, std::string> &result, std::string element_name);
+	// Returns version info for a given element in the system
+	void getElementVersion(
+		ElementResponse &response,
+		std::map<std::string, std::string> &result,
+		std::string element_name);
+
+	// Blocks until all specified elements are up and reporting healthy
+	void waitForElementsHealthy(
+		std::vector<std::string> &elem_list,
+		double retry_interval,
+	  bool strict);
 
 	// Returns a list of all elements
 	enum atom_error_t getAllElements(

--- a/languages/cpp/inc/element.h
+++ b/languages/cpp/inc/element.h
@@ -209,6 +209,10 @@ public:
 	void addCommand(
 		Command *cmd);
 
+	void healthcheckSet(
+		command_handler_t fn,
+		int timeout);
+
 	// Processes incoming commands per the command
 	//	handler table. If no args passed, then will loop indefinitely,
 	//	else will handle only N commands and then will exit

--- a/languages/cpp/inc/element.h
+++ b/languages/cpp/inc/element.h
@@ -29,7 +29,7 @@
 #define ATOM_VERSION_CPP "v0.2.0"
 #define ATOM_VERSION_COMMAND "version"
 #define ATOM_HEALTHCHECK_COMMAND "healthcheck"
-#define ATOM_HEALTHCHECK_RETRY_INTERVAL 5
+#define ATOM_HEALTHCHECK_RETRY_INTERVAL_MS 5000
 
 #define ELEMENT_DEFAULT_N_CONTEXTS 20
 
@@ -189,8 +189,8 @@ public:
 	// Blocks until all specified elements are up and reporting healthy
 	void waitForElementsHealthy(
 		std::vector<std::string> &elem_list,
-		double retry_interval,
-	  bool strict);
+		int retry_interval_ms = ATOM_HEALTHCHECK_RETRY_INTERVAL_MS,
+	  bool strict = true);
 
 	// Returns a list of all elements
 	enum atom_error_t getAllElements(

--- a/languages/cpp/inc/element.h
+++ b/languages/cpp/inc/element.h
@@ -25,6 +25,11 @@
 #include "element_read_map.h"
 #include "command.h"
 
+#define VERSION "v0.2.0"
+#define ATOM_VERSION_COMMAND "version"
+#define ATOM_HEALTHCHECK_COMMAND "healthcheck"
+#define ATOM_HEALTHCHECK_RETRY_INTERVAL 5
+
 #define ELEMENT_DEFAULT_N_CONTEXTS 20
 
 #define ELEMENT_INFINITE_COMMAND_LOOPS 0

--- a/languages/cpp/inc/element.h
+++ b/languages/cpp/inc/element.h
@@ -190,7 +190,7 @@ public:
 	void waitForElementsHealthy(
 		std::vector<std::string> &elem_list,
 		int retry_interval_ms = ATOM_HEALTHCHECK_RETRY_INTERVAL_MS,
-	  bool strict = true);
+		bool strict = true);
 
 	// Returns a list of all elements
 	enum atom_error_t getAllElements(
@@ -219,6 +219,9 @@ public:
 	void addCommand(
 		Command *cmd);
 
+	// Sets a custom healthcheck for this element.
+	//	The user provided command_handler should return err code 0 if healthy,
+	//	non 0 if unhealthy
 	void healthcheckSet(
 		command_handler_t fn,
 		int timeout);

--- a/languages/cpp/inc/element.h
+++ b/languages/cpp/inc/element.h
@@ -11,6 +11,7 @@
 #define __ATOM_CPP_ELEMENT_H
 
 #include <queue>
+#include <set>
 #include <mutex>
 #include <syslog.h>
 #include <iostream>
@@ -25,7 +26,7 @@
 #include "element_read_map.h"
 #include "command.h"
 
-#define VERSION "v0.2.0"
+#define ATOM_VERSION_CPP "v0.2.0"
 #define ATOM_VERSION_COMMAND "version"
 #define ATOM_HEALTHCHECK_COMMAND "healthcheck"
 #define ATOM_HEALTHCHECK_RETRY_INTERVAL 5
@@ -160,6 +161,11 @@ class Element {
 		return true;
 	}
 
+	// Helper function for checking if another element meets version requirements
+	bool checkElementVersion(
+		std::string element,
+		std::set<std::string> supported_language_set,
+		double supported_min_version);
 
 public:
 
@@ -173,6 +179,8 @@ public:
 
 	// Returns the name of the element
 	const std::string &getName();
+
+	void getElementVersion(ElementResponse &response, std::map<std::string, std::string> &result, std::string element_name);
 
 	// Returns a list of all elements
 	enum atom_error_t getAllElements(

--- a/languages/cpp/src/element.cc
+++ b/languages/cpp/src/element.cc
@@ -386,15 +386,23 @@ void Element::getElementVersion(
 	std::string element_name)
 {
 	std::map<std::string, msgpack::object> res;
-	enum atom_error_t err = this->sendCommandNoReq<std::map<std::string, msgpack::object>>(
+	enum atom_error_t err = this->sendCommand(
 		response,
 		element_name,
 		ATOM_VERSION_COMMAND,
-		res
+		NULL,
+		0
 	);
 	if (err != ATOM_NO_ERROR) {
 		return;
 	}
+	// Deserialize version command response
+	msgpack::object_handle oh = msgpack::unpack(
+		response.getData().c_str(),
+		response.getDataLen());
+	msgpack::object deserialized = oh.get();
+	deserialized.convert(res);
+	// Unpack version dictionary
 	result["language"] = res["language"].as<std::string>();
 	std::stringstream ss;
 	ss << res["version"].as<double>();

--- a/languages/cpp/src/element.cc
+++ b/languages/cpp/src/element.cc
@@ -664,7 +664,7 @@ void Element::healthcheckSet(
 	    "Returns whether the element is healthy",
 	    fn,
 			NULL,
-			1000
+			timeout
 		);
 	// Otherwise, update the healthcheck to the new user provided callback/timeout
 	} else {
@@ -675,6 +675,7 @@ void Element::healthcheckSet(
 			fn,
 			NULL,
 			timeout);
+		new_cmd->addElement(this);
 		delete commands[ATOM_HEALTHCHECK_COMMAND];
 		commands[ATOM_HEALTHCHECK_COMMAND] = new_cmd;
 
@@ -1209,7 +1210,7 @@ void Element::getElementVersion(ElementResponse &response, std::map<std::string,
 
 bool Element::checkElementVersion(
 	std::string element_name,
-	std::set<std::string> supported_language_set,
+	std::set<std::string> &supported_language_set,
 	double supported_min_version)
 {
 	ElementResponse response;
@@ -1233,4 +1234,11 @@ bool Element::checkElementVersion(
 	return true;
 }
 
+void Element::waitForElementsHealthy(
+	std::vector<std::string> &elements_list,
+	double retry_interval,
+  bool strict)
+{
+
+}
 } // namespace atom

--- a/languages/cpp/src/element.cc
+++ b/languages/cpp/src/element.cc
@@ -66,7 +66,7 @@ bool get_version_callback(
 	std::string version = ATOM_VERSION_CPP;
 	std::size_t pos = version.find_last_of(".");
 	double major_version = std::stod(version.substr(1, version.length()).substr(0, pos));
-	std::string language = ATOM_LANGUAGE;
+	std::string language = ATOM_LANGUAGE_CPP;
 
 	version_dict["language"] =  msgpack::object(language, zone);
 	version_dict["version"] =  msgpack::object(major_version, zone);
@@ -379,7 +379,10 @@ const std::string &Element::getName()
 //			and populates the result dictionary with the received data.
 //
 ////////////////////////////////////////////////////////////////////////////////
-void Element::getElementVersion(ElementResponse &response, std::map<std::string, std::string> &result, std::string element_name)
+void Element::getElementVersion(
+	ElementResponse &response,
+	std::map<std::string, std::string> &result,
+	std::string element_name)
 {
 	std::map<std::string, msgpack::object> res;
 	enum atom_error_t err = this->sendCommandNoReq<std::map<std::string, msgpack::object>>(
@@ -405,10 +408,10 @@ void Element::getElementVersion(ElementResponse &response, std::map<std::string,
 void Element::waitForElementsHealthy(
 	std::vector<std::string> &elem_list,
 	int retry_interval_ms,
-  bool strict)
+	bool strict)
 {
 	std::set<std::string> supported_language_set;
-	supported_language_set.insert(ATOM_LANGUAGE);
+	supported_language_set.insert(ATOM_LANGUAGE_CPP);
 	supported_language_set.insert("Python");
 	bool all_healthy;
 	while (true) {

--- a/languages/cpp/src/element.cc
+++ b/languages/cpp/src/element.cc
@@ -1302,4 +1302,5 @@ void Element::log(
 		error("Failed to log", false);
 	}
 }
+
 } // namespace atom

--- a/languages/cpp/src/element.cc
+++ b/languages/cpp/src/element.cc
@@ -52,8 +52,6 @@ extern "C" {
 		void *cleanup_ptr);
 }
 
-
-
 bool get_version_callback(
 	const uint8_t *data,
 	size_t data_len,
@@ -64,7 +62,9 @@ bool get_version_callback(
 	{
 			msgpack::zone zone;
 
-			double major_version = 0.2;
+			std::string version = VERSION;
+			std::size_t pos = version.find_last_of(".");
+			double major_version = std::stod(version.substr(1, version.length()).substr(0, pos));
 			std::string language = ATOM_LANGUAGE;
 
 			version_dict["language"] =  msgpack::object(language, zone);
@@ -77,10 +77,14 @@ bool get_version_callback(
 	return true;
 }
 
-
-
-
-
+bool default_healthcheck_callback(
+	const uint8_t *data,
+	size_t data_len,
+	ElementResponse *resp,
+	void *user_data)
+{
+	return true;
+}
 
 // Class for entry info from a handler to be passed to the callback function
 class EntryReadInfo {
@@ -264,7 +268,15 @@ Element::Element(
 		NULL,
 		1000
 	);
+
 	// Add healthcheck callback
+	this->addCommand(
+		ATOM_HEALTHCHECK_COMMAND,
+    "Returns whether the element is healthy (defaults to true)",
+    default_healthcheck_callback,
+		NULL,
+		1000
+	);
 
 	// Release the context
 	releaseContext(ctx);

--- a/languages/cpp/src/element.cc
+++ b/languages/cpp/src/element.cc
@@ -395,7 +395,9 @@ void Element::getElementVersion(
 		return;
 	}
 	result["language"] = res["language"].as<std::string>();
-	result["version"] = std::to_string(res["version"].as<double>());
+	std::stringstream ss;
+	ss << res["version"].as<double>();
+	result["version"] = ss.str();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/languages/cpp/src/element.cc
+++ b/languages/cpp/src/element.cc
@@ -84,6 +84,7 @@ bool default_healthcheck_callback(
 	ElementResponse *resp,
 	void *user_data)
 {
+	resp->setData("healthy");
 	return true;
 }
 

--- a/languages/cpp/src/element.cc
+++ b/languages/cpp/src/element.cc
@@ -84,7 +84,6 @@ bool default_healthcheck_callback(
 	ElementResponse *resp,
 	void *user_data)
 {
-	resp->setData("healthy");
 	return true;
 }
 

--- a/languages/cpp/src/element.cc
+++ b/languages/cpp/src/element.cc
@@ -65,7 +65,7 @@ bool get_version_callback(
 
 	std::string version = ATOM_VERSION_CPP;
 	std::size_t pos = version.find_last_of(".");
-	double major_version = std::stod(version.substr(1, version.length()).substr(0, pos));
+	double major_version = std::stod(version.substr(1, version.length()).substr(0, pos - 1));
 	std::string language = ATOM_LANGUAGE_CPP;
 
 	version_dict["language"] =  msgpack::object(language, zone);

--- a/languages/cpp/src/element.cc
+++ b/languages/cpp/src/element.cc
@@ -52,6 +52,36 @@ extern "C" {
 		void *cleanup_ptr);
 }
 
+
+
+bool get_version_callback(
+	const uint8_t *data,
+	size_t data_len,
+	ElementResponse *resp,
+	void *user_data)
+{
+	std::map< std::string, msgpack::object> version_dict;
+	{
+			msgpack::zone zone;
+
+			double major_version = 0.2;
+			std::string language = ATOM_LANGUAGE;
+
+			version_dict["language"] =  msgpack::object(language, zone);
+			version_dict["version"] =  msgpack::object(major_version, zone);
+
+			std::stringstream ss;
+			msgpack::pack(ss, version_dict);
+			resp->setData(ss.str());
+	}   // zone is auto-destroyed here
+	return true;
+}
+
+
+
+
+
+
 // Class for entry info from a handler to be passed to the callback function
 class EntryReadInfo {
 public:
@@ -225,6 +255,16 @@ Element::Element(
 
 	// Make an element
 	elem = element_init(ctx, name.c_str());
+
+	// Add version callback
+  this->addCommand(
+		ATOM_VERSION_COMMAND,
+    "Retrieves the version info for this element",
+    get_version_callback,
+		NULL,
+		1000
+	);
+	// Add healthcheck callback
 
 	// Release the context
 	releaseContext(ctx);

--- a/languages/cpp/test/test_element.cc
+++ b/languages/cpp/test/test_element.cc
@@ -472,7 +472,7 @@ public:
 
 
 // Thread that creates a command element
-void* command_element(void *data)
+void* command_element(void *data, int n_loops = 1)
 {
 	Element elem("test_cmd");
 	elem.addCommand("hello", "hello, world", hello_callback_fn, NULL, 1000);
@@ -734,7 +734,7 @@ TEST_F(ElementTest, wait_for_elements_healthy) {
 
 	// Start the command thread
 	pthread_t cmd_thread;
-	ASSERT_EQ(pthread_create(&cmd_thread, NULL, command_element, NULL), 0);
+	ASSERT_EQ(pthread_create(&cmd_thread, NULL, command_element, NULL, 2), 0);
 
 	// Wait until the command element is alive
 	while (true) {

--- a/languages/cpp/test/test_element.cc
+++ b/languages/cpp/test/test_element.cc
@@ -694,6 +694,37 @@ TEST_F(ElementTest, err_string) {
 	ASSERT_EQ(pthread_join(cmd_thread, &ret), 0);
 }
 
+// Tests getElementVersion
+TEST_F(ElementTest, err_string) {
+	ElementResponse response;
+
+	// Start the command thread
+	pthread_t cmd_thread;
+	ASSERT_EQ(pthread_create(&cmd_thread, NULL, command_element, NULL), 0);
+
+	// Wait until the command element is alive
+	while (true) {
+		std::vector<std::string> elements;
+		ASSERT_EQ(element->getAllElements(elements), ATOM_NO_ERROR);
+		if (std::find(elements.begin(), elements.end(), "test_cmd") != elements.end()) {
+			break;
+		}
+		usleep(100000);
+	}
+
+	std::map<std::string, std::string> result;
+	element->getElementVersion(response, result, "test_cmd");
+
+	ASSERT_EQ(response.isError(), false);
+	ASSERT_EQ(result["language"],  ATOM_LANGUAGE_CPP);
+	ASSERT_EQ(result["version"],  ATOM_VERSION_CPP);
+
+	// Wait for the command thread to finish
+	void *ret;
+	ASSERT_EQ(pthread_join(cmd_thread, &ret), 0);
+}
+
+
 // Tests sending a log. We'll read it back with a redis XREVRANGE command
 //	 on the log stream
 TEST_F(ElementTest, basic_log) {

--- a/languages/cpp/test/test_element.cc
+++ b/languages/cpp/test/test_element.cc
@@ -712,12 +712,16 @@ TEST_F(ElementTest, get_element_version) {
 		usleep(100000);
 	}
 
+	std::string version = ATOM_VERSION_CPP;
+	std::size_t pos = version.find_last_of(".");
+	std::string major_version = version.substr(1, version.length()).substr(0, pos);
+
 	std::map<std::string, std::string> result;
 	element->getElementVersion(response, result, "test_cmd");
 
 	ASSERT_EQ(response.isError(), false);
 	ASSERT_EQ(result["language"],  ATOM_LANGUAGE_CPP);
-	ASSERT_EQ(result["version"],  ATOM_VERSION_CPP);
+	ASSERT_EQ(result["version"],  major_version);
 
 	// Wait for the command thread to finish
 	void *ret;

--- a/languages/cpp/test/test_element.cc
+++ b/languages/cpp/test/test_element.cc
@@ -695,7 +695,7 @@ TEST_F(ElementTest, err_string) {
 }
 
 // Tests getElementVersion
-TEST_F(ElementTest, err_string) {
+TEST_F(ElementTest, get_element_version) {
 	ElementResponse response;
 
 	// Start the command thread

--- a/languages/cpp/test/test_element.cc
+++ b/languages/cpp/test/test_element.cc
@@ -472,7 +472,7 @@ public:
 
 
 // Thread that creates a command element
-void* command_element(void *data, int n_loops = 1)
+void* command_element(void *num_loops_ptr)
 {
 	Element elem("test_cmd");
 	elem.addCommand("hello", "hello, world", hello_callback_fn, NULL, 1000);
@@ -492,7 +492,11 @@ void* command_element(void *data, int n_loops = 1)
 	elem.addCommand(
 		new MsgpackNoReqNoRes("noreqnores", "Tests msgpack no request or response", 1000));
 
-	elem.commandLoop(1);
+	int num_loops = 1;
+	if (num_loops_ptr != NULL) {
+		num_loops = *((int *) num_loops_ptr);
+	}
+	elem.commandLoop(num_loops);
 	return NULL;
 }
 
@@ -734,7 +738,8 @@ TEST_F(ElementTest, wait_for_elements_healthy) {
 
 	// Start the command thread
 	pthread_t cmd_thread;
-	ASSERT_EQ(pthread_create(&cmd_thread, NULL, command_element, NULL, 2), 0);
+	int num_loops = 2;
+	ASSERT_EQ(pthread_create(&cmd_thread, NULL, command_element, &num_loops), 0);
 
 	// Wait until the command element is alive
 	while (true) {

--- a/languages/python/atom/element.py
+++ b/languages/python/atom/element.py
@@ -336,7 +336,7 @@ class Element:
         self.handler_map[HEALTHCHECK_COMMAND] = {"handler": handler, "deserialize": False}
         self.timeouts[HEALTHCHECK_COMMAND] = RESPONSE_TIMEOUT
 
-    def wait_for_elements_healthy(self, element_list, retry_interval=HEALTHCHECK_RETRY_INTERVAL, strict=False):
+    def wait_for_elements_healthy(self, element_list, retry_interval=HEALTHCHECK_RETRY_INTERVAL, strict=True):
         """
         Blocking call will wait until all elements in the element respond that they are healthy.
 

--- a/languages/python/atom/element.py
+++ b/languages/python/atom/element.py
@@ -352,7 +352,7 @@ class Element:
             all_healthy = True
             for element_name in element_list:
                 # Verify element is reachable and supports healthcheck feature
-                if not self._check_element_version(element_name, supported_language_set={LANG}, supported_min_version=0.2):
+                if not self._check_element_version(element_name, supported_language_set={LANG, 'c'}, supported_min_version=0.2):
                     # In strict mode, if element is not reachable or doesn't support healthchecks, assume unhealthy
                     if strict:
                         self.log(LogLevel.WARNING, f"Failed healthcheck on {element_name}, retrying...")

--- a/languages/python/atom/element.py
+++ b/languages/python/atom/element.py
@@ -352,7 +352,7 @@ class Element:
             all_healthy = True
             for element_name in element_list:
                 # Verify element is reachable and supports healthcheck feature
-                if not self._check_element_version(element_name, supported_language_set={LANG, 'c'}, supported_min_version=0.2):
+                if not self._check_element_version(element_name, supported_language_set={LANG, 'c++'}, supported_min_version=0.2):
                     # In strict mode, if element is not reachable or doesn't support healthchecks, assume unhealthy
                     if strict:
                         self.log(LogLevel.WARNING, f"Failed healthcheck on {element_name}, retrying...")


### PR DESCRIPTION
- Adds version checking to C++ SDK, same as in the python SDK
- Adds health-checking to C++ SDK, same as in the python SDK
- Fixes bug in C SDK which would cause sendCommand attempts to non-existent elements to hang instead of returning NO_ACK errors
- Updates python SDK to allow healthchecking against C++ elements