### PR TITLE
redis.conf: increase maxmemory to 2gb

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -558,7 +558,7 @@ slave-priority 100
 # limit for maxmemory so that there is some free RAM on the system for slave
 # output buffers (but this is not needed if the policy is 'noeviction').
 #
-maxmemory 1gb
+maxmemory 2gb
 
 # MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
 # is reached. You can select among five behaviors:


### PR DESCRIPTION
Temporary fix to issues with command/response streams being too
long and wasting a bunch of memory -- should be able to revert
and/or downsize once that fix is in across the SDK.