### PR TITLE
Cjg/new redis py

### DIFF
--- a/doc/source/includes/acknowledgements.md
+++ b/doc/source/includes/acknowledgements.md
@@ -8,6 +8,7 @@ Atom was architected and developed for Elementary Robotics by [@dpipemazo](https
 - [@arye47](https://github.com/arye47)
 - [@angeladong2018](https://github.com/angeladong2018)
 - [@plipay](https://github.com/plipay)
+- [@Cody-G](https://github.com/Cody-G)
 
 ## Open Source
 

--- a/languages/python/atom/messages.py
+++ b/languages/python/atom/messages.py
@@ -5,6 +5,20 @@ from msgpack import packb
 CMD_RESERVED_KEYS = ("data", "cmd", "element",)
 RES_RESERVED_KEYS = ("data", "err_code", "err_str", "element", "cmd", "cmd_id")
 
+def format_redis_py(data):
+    if data is None:
+        return ""
+    if type(data) is dict:
+        output = {}
+        for k, v in data.items():
+            if v is None:
+                output[k] = ""
+            else:
+                output[k] = v
+        return output
+    else:
+        return data
+
 class Cmd:
     def __init__(self, element, cmd, data, **kwargs):
         """

--- a/languages/python/requirements.txt
+++ b/languages/python/requirements.txt
@@ -1,3 +1,3 @@
-git+git://github.com/nicois/redis-py@master
+redis==3.3.8
 lazycontract==0.9.6
 pytest==3.8.1


### PR DESCRIPTION
This should address #60.  Most of the breaking changes are explained in the redis-py readme [here](https://github.com/andymccurdy/redis-py).  I didn't make an effort to shield atom users from the breaking changes.  You can get an idea of how usage will change by checking out the changes to the test code.  If people prefer the old behavior then we can add more code to process redis-py inputs and outputs internally. However I think that complicates the code base, and may keep getting worse if redis-py continues to change.

Note we'll need to rebase before merging, I'll get #194 merged first.