### PR TITLE
python: add side-channel for raw data

### DIFF
--- a/doc/source/includes/sdk-specification.md
+++ b/doc/source/includes/sdk-specification.md
@@ -758,7 +758,7 @@ def add_2(data):
 my_element.command_add("add_2", add_2, timeout=50, deserialize=True)
 
 # If we're expecting raw data to be sent from the caller in the event of mixed serialization, we can note that with kwargs in our command handler
-def command_with_raw_data(data, raw_key_1=None, raw_key_2 = None):
+def command_with_raw_data(data, raw_key_1=None, raw_key_2=None):
     """
     Expects the caller to call command_send with payload of raw_data={"raw_key_1" : some_data, "raw_key_2" : some_other_data}
 

--- a/doc/source/includes/sdk-specification.md
+++ b/doc/source/includes/sdk-specification.md
@@ -757,14 +757,14 @@ def add_2(data):
 # The deserialize flag will allow the data to be deserialized before it is sent to the add_2 function
 my_element.command_add("add_2", add_2, timeout=50, deserialize=True)
 
-# If we're expecting raw data to be sent from the caller in the event of mixed serialization, we can note that with kwargs in our command handler
+# If we're expecting raw data to be sent from the caller in the event of mixed serialization, we can note that with kwargs in our command handler. Also, we can send raw data in the response with the raw_data kwarg on the Response object. This allows us to still send a primary serialized response but will add raw data to a response dictionary returned to the user.
 def command_with_raw_data(data, raw_key_1=None, raw_key_2=None):
     """
     Expects the caller to call command_send with payload of raw_data={"raw_key_1" : some_data, "raw_key_2" : some_other_data}
 
     The primary data payload here is still serialized using msgpack which is pretty nice.
     """
-    return Response("success")
+    return Response("success", serialize=True, raw_data={"img" : img.bytes()})
 
 my_element.command_add("raw_data_test", command_with_raw_data, deserialize=True)
 ```

--- a/doc/source/includes/sdk-specification.md
+++ b/doc/source/includes/sdk-specification.md
@@ -756,6 +756,17 @@ def add_2(data):
 
 # The deserialize flag will allow the data to be deserialized before it is sent to the add_2 function
 my_element.command_add("add_2", add_2, timeout=50, deserialize=True)
+
+# If we're expecting raw data to be sent from the caller in the event of mixed serialization, we can note that with kwargs in our command handler
+def command_with_raw_data(data, raw_key_1=None, raw_key_2 = None):
+    """
+    Expects the caller to call command_send with payload of raw_data={"raw_key_1" : some_data, "raw_key_2" : some_other_data}
+
+    The primary data payload here is still serialized using msgpack which is pretty nice.
+    """
+    return Response("success")
+
+my_element.command_add("raw_data_test", command_with_raw_data, deserialize=True)
 ```
 
 Adds a command to an element. The element will then "support" this command, allowing other elements to call it.
@@ -949,6 +960,9 @@ response = my_element.command_send("your_element", "your_command", data, block=T
 # If serialized data is expected by the command, pass the serialize flag to the function.
 # If the response of the command is serialized, it can be deserialized with the deserialize flag.
 response = my_element.command_send("your_element", "your_command", data, block=True, serialize=True, deserialize=True)
+
+# If you'd like to use serialization for _most_ of your command but still would like to send a big chunk of unserialized binary data (common for image-based APIs), then you can do so with the raw_data arg
+response = my_element.command_send("your_element", "your_command", data, block=True, serialize=True, deserialize=True, raw_data={"cmd_img" : img.bytes()})
 ```
 
 Sends a command to another element
@@ -961,6 +975,7 @@ Sends a command to another element
 | `command` | String | Command we want to call |
 | `data` | binary/unspecified | Optional data payload for the command |
 | `block` | bool | Optional value to wait for the response to the command. If false will only wait for the ACK from the element and not the response packet, else if true will wait for both the ACK and the response |
+| `raw_data` | map/dict | Currently only supported in Python. Writes any additional key:value pairs without serialization to key:value pairs in the stream used for sending commands. This is useful for commands which need mixed serialization, i.e. need serialization for parameters but not for a big data payload such as an image |
 
 ### Return Value
 
@@ -970,7 +985,7 @@ Object containing error code and response data. Implementation to be specified b
 
 Perform the following steps:
 
-1. `XADD command:$element * ...` where `...` is the "Command Packet Data" from the "Handle Commands" spec. This sends the command to the element. This XADD will return an entry ID that uniquely identifies it and is based on a global millisecond-level redis timestamp. This ID will be used in a few places and will be referred to as `cmd_id`.
+1. `XADD command:$element * ...` where `...` is the "Command Packet Data" from the "Handle Commands" spec. This sends the command to the element. This XADD will return an entry ID that uniquely identifies it and is based on a global millisecond-level redis timestamp. This ID will be used in a few places and will be referred to as `cmd_id`. Primary data will go on a "data" key in the stream. Raw data will be added on additional keys in the stream where the key name will be key from the raw data dict and the value will be the value from the raw data dict.
 2. `XREAD BLOCK 1000 STREAMS response:$self $cmd_id`. This performs a blocking read on our response stream for the ACK packet. Note that we're reading for all entries since our command packet which works nicely since the entry IDs use a global redis timestamp.
 3. If (2) times out, return an error, i.e. we didn't get an ACK
 4. If (2) returns data, loop over the data and look for a packet with matching `element` and `cmd_id` fields.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
         target: /shared
         volume:
           nocopy: true
+      - ".:/atom"
     depends_on:
       - "nucleus"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
         target: /shared
         volume:
           nocopy: true
-      - ".:/atom"
+    # - ".:/atom"
     depends_on:
       - "nucleus"
     ports:

--- a/languages/python/atom/element.py
+++ b/languages/python/atom/element.py
@@ -442,8 +442,7 @@ class Element:
                     self.log(LogLevel.ERR, err_str)
                     response = Response(err_code=ATOM_CALLBACK_FAILED, err_str=err_str)
 
-            response = response.to_internal(self.name, cmd_name, cmd_id)
-            _pipe.xadd(self._make_response_id(caller), maxlen=STREAM_LEN, **vars(response))
+            _pipe.xadd(self._make_response_id(caller), maxlen=STREAM_LEN, **vars(response), cmd=cmd_name, cmd_id=cmd_id, element=self.name)
             _pipe.execute()
             _pipe = self._release_pipeline(_pipe)
 

--- a/languages/python/atom/element.py
+++ b/languages/python/atom/element.py
@@ -483,6 +483,12 @@ class Element:
 
         # Send command to element's command stream
         data = packb(data, use_bin_type=True) if serialize and (data != "") else data
+
+        # Make sure the keyword "data" isn't being used in the raw_data
+        #   dict
+        if "data" in raw_data:
+            raise Exception("'data' cannot be used as a key in raw_data")
+
         cmd = Cmd(self.name, cmd_name, data, **raw_data)
         _pipe = self._rpipeline_pool.get()
         _pipe.xadd(self._make_command_id(element_name), maxlen=STREAM_LEN, **vars(cmd))

--- a/languages/python/atom/messages.py
+++ b/languages/python/atom/messages.py
@@ -4,7 +4,7 @@ from msgpack import packb
 
 
 class Cmd:
-    def __init__(self, element, cmd, data):
+    def __init__(self, element, cmd, data, **kwargs):
         """
         Specifies the format of a command that an element sends to another.
 
@@ -20,6 +20,7 @@ class Cmd:
         self.element = element
         self.cmd = cmd
         self.data = data
+        self.__dict__.update(kwargs)
 
 
 class Response:
@@ -101,7 +102,7 @@ class Entry:
             if not isinstance(field, str):
                 raise TypeError(f"field {field} must be a str")
             setattr(self, field, data)
-            
+
 
 class Acknowledge:
     def __init__(self, element, cmd_id, timeout):

--- a/languages/python/tests/test_atom.py
+++ b/languages/python/tests/test_atom.py
@@ -575,6 +575,7 @@ class TestAtom:
         proc.join()
         assert response["err_code"] == ATOM_NO_ERROR
         assert response["data"] == "success"
+        assert response["raw_test"] == b"hello, world!"
 
 def check_kwargs(data, first_kwarg=None, second_kwarg=None):
     """
@@ -583,7 +584,7 @@ def check_kwargs(data, first_kwarg=None, second_kwarg=None):
     assert data["test"] == "kwarg"
     assert first_kwarg == b"hello"
     assert second_kwarg == b"world"
-    return Response("success", serialize=True)
+    return Response("success", serialize=True, raw_data={"raw_test": "hello, world!"})
 
 def add_1(x):
     return Response(int(x)+1)

--- a/languages/python/tests/test_atom.py
+++ b/languages/python/tests/test_atom.py
@@ -566,7 +566,24 @@ class TestAtom:
         test_empty = EmptyContractTest()
         assert test_empty.to_data() == ""
 
+    def test_raw_data(self, caller, responder):
+        responder.command_add("check_kwargs", check_kwargs, deserialize=True)
+        proc = Process(target=responder.command_loop)
+        proc.start()
+        response = caller.command_send("test_responder", "check_kwargs", {"test" : "kwarg"}, serialize=True, deserialize=True, raw_data={"first_kwarg" : "hello", "second_kwarg" : "world"})
+        proc.terminate()
+        proc.join()
+        assert response["err_code"] == ATOM_NO_ERROR
+        assert response["data"] == "success"
 
+def check_kwargs(data, first_kwarg=None, second_kwarg=None):
+    """
+    Check that the kwargs are correct
+    """
+    assert data["test"] == "kwarg"
+    assert first_kwarg == b"hello"
+    assert second_kwarg == b"world"
+    return Response("success", serialize=True)
 
 def add_1(x):
     return Response(int(x)+1)


### PR DESCRIPTION
This will allow us to msgpack main commands but still
send additional data (such as an image) over the raw data
side-channel and it will be passed as a kwarg to the
handler.

Addition of new side-channel causes no code changes to
existing elements