### PR TITLE
Cjg/ci docs

### DIFF
--- a/doc/Dockerfile
+++ b/doc/Dockerfile
@@ -12,6 +12,10 @@ WORKDIR /code
 
 RUN bundle install
 
+# Copy circleci docs
+COPY --from=elementaryrobotics/atom:latest \
+    /atom/.circleci/README.md /doc/source/includes/circleci.md
+
 # Copy documentation for each element
 RUN mkdir /elements_docs
 COPY --from=elementaryrobotics/element-record \

--- a/doc/source/index.html.md
+++ b/doc/source/index.html.md
@@ -18,6 +18,7 @@ includes:
   - docker-compose
   - walkthrough
   - tutorials
+  - circleci
   - elements
   - acknowledgements
 


### PR DESCRIPTION
Closes #189.

This required me to remove the .circleci folder from atom's .dockerignore, not sure if this will build correctly.  May need to make a separate PR for that and merge it first.

(and I'll rebase this as needed with the other PRs landing)