### PR TITLE
Fix bug where entry data was overwritten on serialization

### DIFF
--- a/languages/python/atom/element.py
+++ b/languages/python/atom/element.py
@@ -684,9 +684,12 @@ class Element:
         """
         self.streams.add(stream_name)
         if serialize:
+            serialized_field_data_map = {}
             for k, v in field_data_map.items():
-                field_data_map[k] = packb(v, use_bin_type=True)
-        entry = Entry(field_data_map)
+                serialized_field_data_map[k] = packb(v, use_bin_type=True)
+            entry = Entry(serialized_field_data_map)
+        else:
+            entry = Entry(field_data_map)
         _pipe = self._rpipeline_pool.get()
         _pipe.xadd(self._make_stream_id(self.name, stream_name), maxlen=maxlen, **vars(entry))
         _pipe.execute()

--- a/languages/python/tests/test_atom.py
+++ b/languages/python/tests/test_atom.py
@@ -86,7 +86,10 @@ class TestAtom:
         proper values are returned from get_n_most_recent.
         """
         for i in range(10):
-            responder.entry_write("test_stream_serialized", {"data": i}, serialize=True)
+            data = {"data": i}
+            responder.entry_write("test_stream_serialized", data, serialize=True)
+            # Ensure that serialization keeps the original data in tact
+            assert data["data"] == i
         entries = caller.entry_read_n("test_responder", "test_stream_serialized", 5, deserialize=True)
         assert len(entries) == 5
         assert entries[0]["data"] == 9


### PR DESCRIPTION
Previously when serialization was true for entry_write, we would
overwrite the provided field_data_map values with serialized values

Now we create a separate dictionary for the serialized data

Tests added to ensure the integrity of the original data as well