### PR TITLE
Copy the circleci markdown to the correct directory during build, don…

### DIFF
--- a/doc/Dockerfile
+++ b/doc/Dockerfile
@@ -14,7 +14,7 @@ RUN bundle install
 
 # Copy circleci docs
 COPY --from=elementaryrobotics/atom:latest \
-    /atom/.circleci/README.md /doc/source/includes/circleci.md
+    /atom/.circleci/README.md /code/source/includes/circleci.md
 
 # Copy documentation for each element
 RUN mkdir /elements_docs

--- a/doc/docker-compose.yml
+++ b/doc/docker-compose.yml
@@ -6,8 +6,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    volumes:
-      - ".:/code"
     ports:
       - "4567:4567"
     command: "bundle exec middleman server"


### PR DESCRIPTION
…'t mount local directory in the image.

This closes #189.