### PR TITLE
#232 - Fix nightly docs build

### DIFF
--- a/doc/Dockerfile
+++ b/doc/Dockerfile
@@ -4,8 +4,8 @@ FROM ubuntu:18.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y build-essential ruby-full zlib1g-dev nodejs
-RUN gem update --system
-RUN gem install bundler
+RUN apt-get install rubygems-integration
+RUN gem install bundler -v '1.17.3'
 
 COPY . /code
 WORKDIR /code


### PR DESCRIPTION
- Specify version of bundler to install per [bundler blogpost](https://bundler.io/blog/2019/01/04/an-update-on-the-bundler-2-release.html)
- Install gem through OS package manager to avoid installing deprecated ruby per [gem issue](https://github.com/rubygems/rubygems/issues/3068)

Resolves #232 
