### PR TITLE
Remove git hash from master tags (#248)

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -149,6 +149,19 @@ circleci orb publish promote elementaryrobotics/atom@dev:some-tag patch
 
 ### Release Notes
 
+## [v0.0.5](https://circleci.com/orbs/registry/orb/elementaryrobotics/atom?version=0.0.5)
+Created 02/05/2020.
+
+##### Bug fixes
+- Removed git commit hashes from deployed `master` image tags
+
+##### Upgrade Steps
+- Reference the v0.0.5 orb in `config.yml` with
+```
+orbs:
+  atom: elementaryrobotics/atom@0.0.5
+```
+
 ## [v0.0.4](https://circleci.com/orbs/registry/orb/elementaryrobotics/atom?version=0.0.4)
 Created 01/31/2020.
 

--- a/.circleci/atom.yml
+++ b/.circleci/atom.yml
@@ -193,7 +193,7 @@ commands:
       - tag_and_deploy:
           source_image: << parameters.source_image >>
           target_image: << parameters.target_image >>
-          target_tag: master-${CIRCLE_BUILD_NUM}-${CIRCLE_SHA1}
+          target_tag: master-${CIRCLE_BUILD_NUM}
       - tag_and_deploy:
           source_image: << parameters.source_image >>
           target_image: << parameters.target_image >>
@@ -250,7 +250,7 @@ jobs:
       - tag_and_deploy:
           source_image: ${CIRCLE_PROJECT_REPONAME}-${CIRCLE_WORKFLOW_ID}
           target_image: ${DOCKERHUB_ORG}/${DOCKERHUB_REPO}
-          target_tag: master-${CIRCLE_BUILD_NUM}-${CIRCLE_SHA1}
+          target_tag: master-${CIRCLE_BUILD_NUM}
           output_timeout: << parameters.output_timeout >>
       - tag_and_deploy:
           source_image: ${CIRCLE_PROJECT_REPONAME}-${CIRCLE_WORKFLOW_ID}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ aliases:
 version: 2.1
 
 orbs:
-  atom: elementaryrobotics/atom@0.0.2
+  atom: elementaryrobotics/atom@0.0.5
 
 jobs:
   build-atom:


### PR DESCRIPTION
Resolves #248 

Published dev orb at `elementaryrobotics/atom@dev:243` which should be promoted to prod