### PR TITLE
Run graphics app with python2

### DIFF
--- a/Dockerfile-atom
+++ b/Dockerfile-atom
@@ -169,5 +169,9 @@ RUN echo "user ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/user
 COPY third-party/docker-opengl/etc /etc
 COPY third-party/docker-opengl/usr /usr
 
+# Need to run app with python2 instead of python3
+RUN var='#!/usr/bin/env python2' \
+ && sed -i "1s@.*@${var}@" /usr/bin/graphical-app-launcher.py
+
 ENV DISPLAY :0
 


### PR DESCRIPTION
Edit graphics app shebang to explicitly use python2 - required now since we are defaulting to python3.