### PR TITLE
Revert "Bump rack from 2.0.5 to 2.2.2 in /doc"

### DIFF
--- a/doc/Gemfile.lock
+++ b/doc/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
       activesupport (>= 3.1)
     parallel (1.10.0)
     public_suffix (2.0.5)
-    rack (2.2.2)
+    rack (2.0.5)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)


### PR DESCRIPTION
This reverts commit 69706ecc3d7116f6a0d6aa4e8034466fb83e98a4.