### PR TITLE
Remove latest bump from tagged builds (Issue #275)

### DIFF
--- a/.circleci/atom.yml
+++ b/.circleci/atom.yml
@@ -374,8 +374,6 @@ examples:
                   branches:
                     only:
                       - master
-                  tags:
-                    only: /.*/
             - atom/deploy-tag:
                 requires:
                   - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -454,8 +454,6 @@ workflows:
             branches:
               only:
                 - master
-            tags:
-              only: /.*/
       - deploy-tag:
           requires:
             - build-opengl
@@ -485,8 +483,6 @@ workflows:
             branches:
               only:
                 - master
-            tags:
-              only: /.*/
       - deploy-tag-docs:
           requires:
             - build-docs

--- a/Dockerfile-atom
+++ b/Dockerfile-atom
@@ -68,6 +68,10 @@ WORKDIR /atom
 
 FROM $BASE_IMAGE as prod
 
+# Cache buster env var - change date to invalidate subsequent caching
+# See the atom README "Atom Dockerfile" section for more information
+ENV LAST_UPDATED 2019-03-06
+
 # Install python
 RUN apt-get update -y \
  && apt-get install -y --no-install-recommends apt-utils \

--- a/README.md
+++ b/README.md
@@ -233,11 +233,18 @@ use of docker layer caching in our build process of the `prod` stage.
 
 To build a specific stage of `atom`, use the `--target` option with `docker build` and an appropriate tag:
 ```
-docker build --no-cache -f Dockerfile-atom -t elementaryrobotics/atom-test:dev --target=test .
+docker build -f Dockerfile-atom -t elementaryrobotics/atom-test:dev --target=test .
 ```
 
 The `prod` stage will be pushed to dockerhub through the CircleCI build process as just `atom`, while the `test`
 stage will be pushed as `atom-test`.
+
+If a build fails due to a third-party dependency "not found" error, it might be because the image layer that does the
+`apt-get update` has been cached, and so an `apt-get install` command is trying to install a library version that is
+no longer available. To break the cache of this layer, either run the entire build process with the `--no-cache` flag
+if building locally, or update the `LAST_UPDATED` environment variable in the Dockerfile to the current date in order to
+invalidate the cache on any subsequent commands. If necessary, `LAST_UPDATED` environment variables can be added at any
+point within the Dockerfile to invalidate all subsequent caching.
 
 ### OpenGL and Cuda support
 


### PR DESCRIPTION
See #275 

An initial build on this PR failed because an `apt-get update` was cached, but the version of a library it tried to download was no longer available. I created a `LAST_UPDATED` env var within the Dockerfile to use for invalidating the `apt-get update` cache when necessary.