### PR TITLE
Update flake8 check to run as job in docker image

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -149,6 +149,51 @@ circleci orb publish promote elementaryrobotics/atom@dev:some-tag patch
 
 ### Release Notes
 
+#### [v0.0.9](https://circleci.com/orbs/registry/orb/elementaryrobotics/atom?version=0.0.9)
+Created 03/12/2020.
+
+##### New features
+- Changed the flake8 format check command to a job that is run within the [`alpine/flake8` docker image](https://hub.docker.com/r/alpine/flake8).
+
+##### Upgrade Steps
+- Reference the v0.0.9 orb in `config.yml` with
+
+```
+orbs:
+  atom: elementaryrobotics/atom@0.0.9
+```
+
+- Use the job for running `flake8` in your build config's workflow, preferably first requiring the build/test step to pass, and
+  then requiring the `flake8` job to pass before deploying any images, as shown below. The job now runs in the `alpine/flake8`
+  docker image, and the python version to use can be passed in as a parameter that will also be used as the docker image tag.
+  Available python versions/image tags can be viewed on dockerhub [here](https://hub.docker.com/r/alpine/flake8/tags).
+
+```diff
+  jobs:
+    - build:
+        filters:
+          tags:
+            only: /.*/
++   - atom/check_flake8:
++       requires:
++         - build
++       version: 3.7.0
++       exclude: doc,*third-party
++       filters:
++         tags:
++           only: /.*/
+    - atom/deploy-master:
+        requires:
+-         - build
++         - atom/check_flake8
+        filters:
+          branches:
+            only:
+              - master
+          tags:
+            only: /.*/
+```
+
 #### [v0.0.8](https://circleci.com/orbs/registry/orb/elementaryrobotics/atom?version=0.0.8)
 Created 03/09/2020.
 

--- a/.circleci/atom.yml
+++ b/.circleci/atom.yml
@@ -79,12 +79,12 @@ commands:
             cat .flake8
       - run:
           name: Install flake8
-          command: python3 -m venv ~/venv && . ~/venv/bin/activate && pip install flake8
+          command: pyenv install 3.6.8 && pyenv global 3.6.8 && pip install flake8
       - run:
           name: Run flake8 check
           command: |
             export LC_ALL=C.UTF-8 && export LANG=C.UTF-8
-            . ~/venv/bin/activate && flake8 << parameters.directory >>
+            flake8 << parameters.directory >>
 
   # Log into docker
   docker_login:

--- a/.circleci/atom.yml
+++ b/.circleci/atom.yml
@@ -54,38 +54,6 @@ commands:
             ssh-keyscan -H github.com >> ~/.ssh/known_hosts
             ssh git@github.com git-lfs-authenticate "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" download
 
-  # Run flake8 format check
-  check_flake8:
-    description: Check that code conforms with flake8 formatting
-    parameters:
-      exclude:
-        description: Comma separated list of directories to exclude when running flake8
-        type: string
-        default: ""
-      directory:
-        description: Directory to run flake8 format check from
-        type: string
-        default: "."
-    steps:
-      - run:
-          name: Create .flake8 config file
-          command: |
-            echo "[flake8]" > .flake8
-            echo "exclude = << parameters.exclude >>" >> .flake8
-            echo "max-line-length = 120" >> .flake8
-            echo "max-doc-length = 80" >> .flake8
-            echo "select = C,E,F,W,B" >> .flake8
-            echo "ignore = E203,W503" >> .flake8
-            cat .flake8
-      - run:
-          name: Install flake8
-          command: pyenv install 3.6.8 && pyenv global 3.6.8 && pip install flake8
-      - run:
-          name: Run flake8 check
-          command: |
-            export LC_ALL=C.UTF-8 && export LANG=C.UTF-8
-            flake8 << parameters.directory >>
-
   # Log into docker
   docker_login:
     description: "Logs into Dockerhub"
@@ -270,6 +238,42 @@ commands:
 #
 jobs:
 
+  # Run flake8 format check
+  check_flake8:
+    docker:
+      - image: alpine/flake8:<< parameters.version >>
+    description: Check that code conforms with flake8 formatting
+    parameters:
+      version:
+        description: Python version to run
+        type: string
+        default: 3.7.0
+      exclude:
+        description: Comma separated list of directories to exclude when running flake8
+        type: string
+        default: ""
+      directory:
+        description: Directory to run flake8 format check from
+        type: string
+        default: "."
+    steps:
+      - checkout
+      - run:
+          name: Create .flake8 config file
+          command: |
+            echo "[flake8]" > .flake8
+            echo "exclude = << parameters.exclude >>" >> .flake8
+            echo "max-line-length = 120" >> .flake8
+            echo "max-doc-length = 80" >> .flake8
+            echo "select = C,E,F,W,B" >> .flake8
+            echo "ignore = E203,W503" >> .flake8
+            cat .flake8
+      - run:
+          name: Run flake8 check
+          command: |
+            export LC_ALL=C.UTF-8 && export LANG=C.UTF-8
+            flake8 << parameters.directory >>
+
   # Tag and deploy a development image
   deploy-dev:
     executor: build-classic
@@ -344,8 +348,6 @@ examples:
             DOCKER_COMPOSE_SERVICE_NAME: some_service
           steps:
             - checkout
-            - atom/check_flake8:
-                exclude: doc,*third-party
             - atom/docker_login
             - atom/build_and_launch:
                 file: docker-compose.yml
@@ -367,16 +369,24 @@ examples:
                 filters:
                   tags:
                     only: /.*/
-            - atom/deploy-master:
+            - atom/check_flake8:
                 requires:
                   - build
+                version: 3.7.0
+                exclude: doc,*third-party
+                filters:
+                  tags:
+                    only: /.*/
+            - atom/deploy-master:
+                requires:
+                  - atom/check_flake8
                 filters:
                   branches:
                     only:
                       - master
             - atom/deploy-tag:
                 requires:
-                  - build
+                  - atom/check_flake8
                 filters:
                   branches:
                     ignore:
@@ -385,7 +395,7 @@ examples:
                     only: /.*/
             - atom/deploy-dev:
                 requires:
-                  - build
+                  - atom/check_flake8
                 filters:
                   branches:
                     ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ aliases:
 version: 2.1
 
 orbs:
-  atom:  elementaryrobotics/atom@dev:276
+  atom:  elementaryrobotics/atom@0.0.9
 
 jobs:
   build-atom:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ aliases:
 version: 2.1
 
 orbs:
-  atom:  elementaryrobotics/atom@0.0.8
+  atom:  elementaryrobotics/atom@dev:276
 
 jobs:
   build-atom:
@@ -51,9 +51,6 @@ jobs:
       - checkout
       - update_submodules
       - set_atom_version
-      - atom/check_flake8:
-          # not currently checking any atom code (it does not pass)
-          exclude: demo,doc,examples,utilities,*third-party,languages
       - atom/docker_login
 
       # Build base, prod and test stages of atom image
@@ -423,23 +420,31 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - atom/check_flake8:
+          version: 3.7.0
+          exclude: demo,doc,examples,utilities,*third-party,languages
+          requires:
+            - test-atom
+          filters:
+            tags:
+              only: /.*/
 
       # Build special images after tests pass for atom
       - build-opengl:
           requires:
-            - test-atom
+            - atom/check_flake8
           filters:
             tags:
               only: /.*/
       - build-cuda:
           requires:
-            - test-atom
+            - atom/check_flake8
           filters:
             tags:
               only: /.*/
       - build-opengl-cuda:
           requires:
-            - test-atom
+            - atom/check_flake8
           filters:
             tags:
               only: /.*/

--- a/Dockerfile-atom
+++ b/Dockerfile-atom
@@ -106,8 +106,13 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Install test dependencies
 #
 
+# Cache buster env var - change date to invalidate subsequent caching
+# See the atom README "Atom Dockerfile" section for more information
+ENV LAST_UPDATED 2019-03-12
+
 # Install googletest
-RUN apt-get install -y --no-install-recommends libgtest-dev cmake build-essential \
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends libgtest-dev cmake build-essential \
  && cd /usr/src/gtest \
  && cmake CMakeLists.txt && make -j16 && cp *.a /usr/lib
 


### PR DESCRIPTION
Update to PR #284 addressing Issue #276.

The flake8 format check has been changed from a command to a job, which is run in the `alpine/flake8` docker image. The python version to use is now a parameter which also determines which image tag to use. The available image tags corresponding to python versions can be viewed on [dockerhub](https://hub.docker.com/r/alpine/flake8). The default python version/image tag is set to `3.7.0`. See updated docs included in this PR for instructions on use.

This orb will need promotion to production version `0.0.9`.