### PR TITLE
286/add submodule orb

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -149,6 +149,40 @@ circleci orb publish promote elementaryrobotics/atom@dev:some-tag patch
 
 ### Release Notes
 
+#### [v0.0.10](https://circleci.com/orbs/registry/orb/elementaryrobotics/atom?version=0.0.10)
+Created 03/12/2020.
+
+##### New features
+- Added `update_submodules` command so that all elements with submodules don't have to write their own.
+- Parallelized `update_submodules` across 8 jobs s.t. it speeds up the clone a bit to save some build time/$$.
+
+##### Upgrade Steps
+- Reference the v0.0.10 orb in `config.yml` with
+
+```
+orbs:
+  atom: elementaryrobotics/atom@0.0.10
+```
+
+- You can now use `atom/update_submodules` as a command in order to clone all submodules in your build. This
+is typically done after the `checkout` step.
+
+```diff
+ build-atom:
+     executor: atom/build-classic
+     resource_class: large
+     environment:
+       <<: *atom_build_vars
+     steps:
+       - checkout
++      - atom/update_submodules
+       - set_atom_version
+       - atom/docker_login
+
+       ...
+
+```
+
 #### [v0.0.9](https://circleci.com/orbs/registry/orb/elementaryrobotics/atom?version=0.0.9)
 Created 03/12/2020.
 

--- a/.circleci/atom.yml
+++ b/.circleci/atom.yml
@@ -54,6 +54,13 @@ commands:
             ssh-keyscan -H github.com >> ~/.ssh/known_hosts
             ssh git@github.com git-lfs-authenticate "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" download
 
+  # Update submodules (parallelized)
+  update_submodules:
+    steps:
+      - run:
+          name: Update Submodules
+          command: git submodule update --init --recursive --jobs 8
+
   # Log into docker
   docker_login:
     description: "Logs into Dockerhub"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ aliases:
 version: 2.1
 
 orbs:
-  atom:  elementaryrobotics/atom@dev:277
+  atom:  elementaryrobotics/atom@dev:286
 
 jobs:
   build-atom:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ aliases:
 version: 2.1
 
 orbs:
-  atom:  elementaryrobotics/atom@0.0.9
+  atom:  elementaryrobotics/atom@dev:277
 
 jobs:
   build-atom:
@@ -49,7 +49,7 @@ jobs:
       <<: *atom_build_vars
     steps:
       - checkout
-      - update_submodules
+      - atom/update_submodules
       - set_atom_version
       - atom/docker_login
 
@@ -84,7 +84,7 @@ jobs:
 
     steps:
       - checkout
-      - update_submodules
+      - atom/update_submodules
       - set_atom_version
       - atom/docker_login
 
@@ -130,7 +130,7 @@ jobs:
       <<: *atom_build_vars
     steps:
       - checkout
-      - update_submodules
+      - atom/update_submodules
       - set_atom_version
       - atom/docker_login
 
@@ -168,7 +168,7 @@ jobs:
       <<: *atom_build_vars
     steps:
       - checkout
-      - update_submodules
+      - atom/update_submodules
       - set_atom_version
       - atom/docker_login
 
@@ -207,7 +207,7 @@ jobs:
       BASE_IMAGE_TAG: v1.0.0
     steps:
       - checkout
-      - update_submodules
+      - atom/update_submodules
       - set_atom_version
       - atom/docker_login
 
@@ -382,12 +382,6 @@ commands:
             docker tag << parameters.image_tag >> registry.heroku.com/${HEROKU_APP_NAME}/web
             docker push registry.heroku.com/${HEROKU_APP_NAME}/web
             heroku container:release -a ${HEROKU_APP_NAME} web
-
-  update_submodules:
-    steps:
-      - run:
-          name: Update Submodules
-          command: git submodule update --init --recursive
 
   set_atom_version:
     steps:


### PR DESCRIPTION
Dev orb published under `dev:286`. Figured it would be nice to share the submodule cloning command as a shared command in the orb. Eventually we might want a few separate orbs -- `atom` and `dev-basics` or something like that but for now having it all in `atom` is likely OK. 

One note is there is now a `--jobs` flag for the submodule update which I believe parallelizes the clone in order to speed it up a touch if there are multiple submodules being cloned. At a quick glance this seems like it perhaps took our "Update Submodules" step down from 9s to 6s.