### PR TITLE
Dockerfile-atom: Set up LD_LIBRARY_PATH

### DIFF
--- a/Dockerfile-atom
+++ b/Dockerfile-atom
@@ -82,6 +82,9 @@ RUN apt-get update -y \
 COPY --from=base /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
+# Set up LD_LIBRARY_PATH s.t. the C/C++ binaries can be found
+ENV LD_LIBRARY_PATH /lib:/usr/local/lib
+
 # Copy C builds
 COPY --from=base /usr/local/lib /usr/local/lib
 COPY --from=base /usr/local/include /usr/local/include
@@ -183,4 +186,3 @@ RUN var='#!/usr/bin/env python2' \
  && sed -i "1s@.*@${var}@" /usr/bin/graphical-app-launcher.py
 
 ENV DISPLAY :0
-


### PR DESCRIPTION
This allows us to natively find the C/C++ atom libraries
in /usr/local/lib when compiling against them without having to
add the same line in this commit to each Dockerfile of an element
being built with the C/C++ bindings