### PR TITLE
Fix failing flake8 step on tag builds

### DIFF
--- a/.circleci/Dockerfile-flake8
+++ b/.circleci/Dockerfile-flake8
@@ -1,0 +1,3 @@
+FROM alpine/atom-flake8:3.7.0
+
+RUN apk add git openssh

--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -149,6 +149,20 @@ circleci orb publish promote elementaryrobotics/atom@dev:some-tag patch
 
 ### Release Notes
 
+#### [v0.0.11](https://circleci.com/orbs/registry/orb/elementaryrobotics/atom?version=0.0.11)
+Created 04/07/2020.
+
+##### Bug fixes
+- Run flake8 format check in custom docker image with git and ssh installed to fix failed builds on tags.
+
+##### Upgrade Steps
+- Reference the v0.0.11 orb in `config.yml` with
+
+```
+orbs:
+  atom: elementaryrobotics/atom@0.0.11
+```
+
 #### [v0.0.10](https://circleci.com/orbs/registry/orb/elementaryrobotics/atom?version=0.0.10)
 Created 03/12/2020.
 

--- a/.circleci/atom.yml
+++ b/.circleci/atom.yml
@@ -248,7 +248,7 @@ jobs:
   # Run flake8 format check
   check_flake8:
     docker:
-      - image: alpine/flake8:<< parameters.version >>
+      - image: elementaryrobotics/atom-flake8
     description: Check that code conforms with flake8 formatting
     parameters:
       version:
@@ -264,9 +264,6 @@ jobs:
         type: string
         default: "."
     steps:
-      - run:
-          name: Install git and ssh
-          command: apk add git openssh
       - checkout
       - run:
           name: Create .flake8 config file

--- a/.circleci/atom.yml
+++ b/.circleci/atom.yml
@@ -264,6 +264,9 @@ jobs:
         type: string
         default: "."
     steps:
+      - run:
+          name: Install git and ssh
+          command: apk add git openssh
       - checkout
       - run:
           name: Create .flake8 config file

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ aliases:
 version: 2.1
 
 orbs:
-  atom:  elementaryrobotics/atom@dev:fix_tag_build_flake8
+  atom:  elementaryrobotics/atom@0.0.11
 
 jobs:
   build-atom:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ aliases:
 version: 2.1
 
 orbs:
-  atom:  elementaryrobotics/atom@dev:286
+  atom:  elementaryrobotics/atom@dev:fix_tag_build_flake8
 
 jobs:
   build-atom:


### PR DESCRIPTION
Install git and openssh in flake8 container.

Atom orb needs updating to prod before merge.