### PR TITLE
atom tagging: improve

### DIFF
--- a/.circleci/atom.yml
+++ b/.circleci/atom.yml
@@ -383,6 +383,24 @@ commands:
       - tag_and_push_image_variant:
           << : *deploy_shared_args_mapping
 
+  deploy_image_no_variant_platform:
+    parameters:
+      << : *deploy_shared_args
+      target_tag_cmd:
+        type: string
+        default: grep ".*"
+    steps:
+      - docker_login
+      - pull_image:
+          source_image: << parameters.source_image >>
+          source_tag: << parameters.source_tag >>
+      - tag_and_push_image:
+          source_image: << parameters.source_image >>
+          source_tag: << parameters.source_tag >>
+          target_image: << parameters.target_image >>
+          target_tag: << parameters.target_tag >>
+          target_tag_cmd: << parameters.target_tag_cmd >>
+
   # Prepare the machine for buildx based builds
   enable_buildx:
     description: "Prepare the CircleCI machine for cross-compiling ARM images"
@@ -646,6 +664,21 @@ jobs:
     steps:
       - setup_remote_docker
       - deploy_image:
+          << : *deploy_shared_args_mapping
+
+  # Deploy without appending the -variant-platform tag. Shouldn't be used
+  # except for special cases.
+  deploy_no_variant_platform:
+    parameters:
+      << : *deploy_shared_args
+      target_tag_cmd:
+        type: string
+        # Deploy exactly as seen
+        default: grep '.*'
+    executor: docker-in-docker
+    steps:
+      - setup_remote_docker
+      - deploy_image_no_variant_platform:
           << : *deploy_shared_args_mapping
 
 examples:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,7 +212,7 @@ aliases:
 version: 2.1
 
 orbs:
-  atom:  elementaryrobotics/atom@0.1.3
+  atom:  elementaryrobotics/atom@dev:315-fix-deploy
 
 commands:
 
@@ -259,7 +259,7 @@ commands:
       - run:
           command: |
             docker login --username=_ --password=<< pipeline.parameters.heroku_api_key >> registry.heroku.com
-            docker tag << parameters.source_image >>:<< parameters.source_tag >> registry.heroku.com/${HEROKU_APP_NAME}/web
+            docker tag << parameters.source_image >>:<< parameters.source_tag >>-stock-amd64 registry.heroku.com/${HEROKU_APP_NAME}/web
             docker push registry.heroku.com/${HEROKU_APP_NAME}/web
             heroku container:release -a << pipeline.parameters.heroku_app_name >> web
 
@@ -1077,12 +1077,13 @@ workflows:
             - "build-base-<< matrix.variant >>-<< matrix.platform >>"
 
       # Bump the base tags when merging into master
-      - atom/deploy:
+      - atom/deploy_no_variant_platform:
           name: "deploy-base-master-<< matrix.source_tag >>"
           source_image: << pipeline.parameters.dockerhub_org >>/<< pipeline.parameters.atom_repo_name >>
           target_image: << pipeline.parameters.dockerhub_org >>/<< pipeline.parameters.atom_repo_name >>
           target_tag: << matrix.source_tag >>
-          target_tag_cmd: sed s/-stock//g | sed s/-amd64//g | grep -oP '[\-a-z0-9]+(?=-[0-9]+)'
+          # Should wind up being "base, base-opengl, base-aarch64, etc."
+          target_tag_cmd: sed s/-stock//g | sed s/-amd64//g | grep -oP '[\.\-a-z0-9]+(?=-[0-9]+)'
           matrix:
             parameters:
               << : *base_build_tags
@@ -1090,6 +1091,24 @@ workflows:
             branches:
               only:
                 - master
+
+      # Bump the base tags when tagging
+      - atom/deploy_no_variant_platform:
+          name: "deploy-base-master-<< matrix.source_tag >>"
+          source_image: << pipeline.parameters.dockerhub_org >>/<< pipeline.parameters.atom_repo_name >>
+          target_image: << pipeline.parameters.dockerhub_org >>/<< pipeline.parameters.atom_repo_name >>
+          target_tag: ${CIRCLE_TAG}-<< matrix.source_tag >>
+          # Should wind up being "v1.4.1-base, v1.4.1-base-opengl, v1.4.1-base-aarch64, etc."
+          target_tag_cmd: sed s/-stock//g | sed s/-amd64//g | grep -oP '[\.\-a-z0-9]+(?=-[0-9]+)'
+          matrix:
+            parameters:
+              << : *base_build_tags
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only: /.*/
 
 
   #


### PR DESCRIPTION
- bump orb in order to have a deploy command without
auto-adding -variant-platform
- Use above orb to fix base master deploy
- Add base tag deploy
- Fix docs push to heroku