### PR TITLE
301/opencv

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -122,6 +122,35 @@ Then, when ready, promote to production (limited to ER staff only)
 circleci orb publish promote elementaryrobotics/atom@dev:some-tag patch
 ```
 
+
+### Release Notes
+
+#### [v0.1.6](https://circleci.com/orbs/registry/orb/elementaryrobotics/atom?version=0.1.6)
+
+##### New Features
+
+- Adds `use_git_lfs` option to builds. If set to `true`, will install `git-lfs`
+on the machine before `checkout` so that the proper files are downloaded.
+
+##### Upgrade Steps
+
+Use in your workflows like below:
+```
+      - atom/build_buildx:
+          name: "build-<< matrix.platform >>"
+          matrix:
+            parameters:
+              platform: [ amd64, aarch64 ]
+          image_name: << pipeline.parameters.dockerhub_repo >>
+          image_tag: build-<< pipeline.number >>
+          cache_repo: << pipeline.parameters.dockerhub_repo >>
+          cache_tag: cache
+          use_git_lfs: true
+          filters:
+            tags:
+              only: /.*/
+```
+
 ### Release Notes
 
 #### [v0.1.5](https://circleci.com/orbs/registry/orb/elementaryrobotics/atom?version=0.1.5)

--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -124,6 +124,13 @@ circleci orb publish promote elementaryrobotics/atom@dev:some-tag patch
 
 ### Release Notes
 
+#### [v0.1.5](https://circleci.com/orbs/registry/orb/elementaryrobotics/atom?version=0.1.5)
+
+##### New Features
+
+- Fixes `test` command/job for `aarch64`
+- Updates/tweaks to examples
+
 #### [v0.1.4](https://circleci.com/orbs/registry/orb/elementaryrobotics/atom?version=0.1.4)
 
 ##### New Features

--- a/.circleci/atom.yml
+++ b/.circleci/atom.yml
@@ -922,6 +922,7 @@ examples:
                 source_image: << pipeline.parameters.dockerhub_repo >>
                 source_tag: build-<< pipeline.number >>
                 target_image: << pipeline.parameters.dockerhub_repo >>
+                target_tag: ""
                 matrix:
                   parameters:
                     variant: [ << pipeline.parameters.atom_variant >> ]

--- a/.circleci/atom.yml
+++ b/.circleci/atom.yml
@@ -38,6 +38,9 @@ aliases:
       no_output_timeout:
         type: string
         default: 15m
+      use_git_lfs:
+        type: boolean
+        default: false
 
   # Mapping to pass build args through without modification
   - &build_basic_args_mapping
@@ -49,6 +52,7 @@ aliases:
       stage: << parameters.stage >>
       build_args: << parameters.build_args >>
       no_output_timeout: << parameters.no_output_timeout >>
+      use_git_lfs: << parameters.use_git_lfs >>
 
   # Basic docker build command. Uses shared args
   - &build_basic_command >-
@@ -486,6 +490,10 @@ commands:
     parameters:
       << : *build_basic_args
     steps:
+      - when:
+          condition: << parameters.use_git_lfs >>
+          steps:
+            - install_git_lfs
       - checkout
       - update_submodules
       - docker_login
@@ -502,6 +510,10 @@ commands:
       << : *build_basic_args
       << : *build_buildx_additional_args
     steps:
+      - when:
+          condition: << parameters.use_git_lfs >>
+          steps:
+            - install_git_lfs
       - checkout
       - update_submodules
       - docker_login
@@ -715,7 +727,7 @@ examples:
             target_image: << pipeline.parameters.dockerhub_repo >>
 
       orbs:
-        atom: elementaryrobotics/atom@0.1.4
+        atom: elementaryrobotics/atom@0.1.6
 
       workflows:
         version: 2
@@ -830,7 +842,7 @@ examples:
           default: elementaryrobotics/example-element
 
       orbs:
-        atom: elementaryrobotics/atom@0.1.4
+        atom: elementaryrobotics/atom@0.1.6
 
       workflows:
         version: 2

--- a/.circleci/atom.yml
+++ b/.circleci/atom.yml
@@ -518,6 +518,7 @@ commands:
     parameters:
       << : *test_shared_args
     steps:
+      - enable_buildx
       - run_compose:
           file: << parameters.compose_file >>
           build_args: << parameters.compose_addl_args >> NUCLEUS_IMAGE=<< parameters.nucleus_repo >>:<< parameters.atom_version >>-stock-<< parameters.platform >> TEST_IMAGE=<< parameters.test_image >>:<< parameters.test_tag >>-<< parameters.variant >>-<< parameters.platform >>
@@ -695,7 +696,7 @@ examples:
           default: elementaryrobotics/atom
         atom_version:
           type: string
-          default: v1.3.1
+          default: v1.4.1
         atom_variant:
           type: string
           default: stock
@@ -820,10 +821,10 @@ examples:
           default: elementaryrobotics/atom
         atom_version:
           type: string
-          default: v1.3.1
+          default: v1.4.1
         atom_variant:
           type: string
-          default: stock
+          default: opencv
         dockerhub_repo:
           type: string
           default: elementaryrobotics/example-element
@@ -841,13 +842,12 @@ examples:
                 name: "build-<< matrix.platform >>"
                 matrix:
                   parameters:
-                    variant: [ << pipeline.parameters.atom_variant >> ]
                     platform: [ amd64, aarch64 ]
                 image_name: << pipeline.parameters.dockerhub_repo >>
                 image_tag: build-<< pipeline.number >>
                 cache_repo: << pipeline.parameters.dockerhub_repo >>
                 cache_tag: cache
-                build_args: --build-arg ATOM_IMAGE=<< pipeline.parameters.atom_repo >>:<< pipeline.parameters.atom_version >>-<< matrix.variant >>-<< matrix.platform >>
+                build_args: --build-arg ATOM_IMAGE=<< pipeline.parameters.atom_repo >>:<< pipeline.parameters.atom_version >>-<< pipeline.parameters.atom_variant >>-<< matrix.platform >>
                 filters:
                   tags:
                     only: /.*/
@@ -857,7 +857,6 @@ examples:
                 name: "test-<< matrix.platform >>"
                 matrix:
                   parameters:
-                    variant: [ << pipeline.parameters.atom_variant >> ]
                     platform: [ amd64, aarch64 ]
                 test_image: << pipeline.parameters.dockerhub_repo >>
                 test_tag: build-<< pipeline.number >>
@@ -889,7 +888,6 @@ examples:
                 target_tag: development-<< pipeline.number >>
                 matrix:
                   parameters:
-                    variant: [ << pipeline.parameters.atom_variant >> ]
                     platform: [ amd64, aarch64 ]
                 requires:
                   - build-<< matrix.platform >>
@@ -907,7 +905,6 @@ examples:
                 target_tag: master-<< pipeline.number >>
                 matrix:
                   parameters:
-                    variant: [ << pipeline.parameters.atom_variant >> ]
                     platform: [ amd64, aarch64 ]
                 requires:
                   - build-<< matrix.platform >>
@@ -925,7 +922,6 @@ examples:
                 target_tag: ""
                 matrix:
                   parameters:
-                    variant: [ << pipeline.parameters.atom_variant >> ]
                     platform: [ amd64, aarch64 ]
                 requires:
                   - build-<< matrix.platform >>
@@ -943,7 +939,6 @@ examples:
                 target_tag: ${CIRCLE_TAG}
                 matrix:
                   parameters:
-                    variant: [ << pipeline.parameters.atom_variant >> ]
                     platform: [ amd64, aarch64 ]
                 requires:
                   - build-<< matrix.platform >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,7 @@ aliases:
   # Base Build Matrix
   - &base_matrix
       parameters:
-        variant: ["stock", "opengl", "cuda", "opengl-cuda", "opencv"]
+        variant: ["stock", "opengl", "cuda", "opengl-cuda", "opengl-cuda-vnc", "opencv"]
         platform: ["amd64", "aarch64"]
       exclude:
         - variant: "opengl"
@@ -167,6 +167,8 @@ aliases:
         - variant: "cuda"
           platform: "aarch64"
         - variant: "opengl-cuda"
+          platform: "aarch64"
+        - variant: "opengl-cuda-vnc"
           platform: "aarch64"
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,8 +175,9 @@ aliases:
   # Base tags in use for the various builds
   - &base_build_atom_tag "base-1024-stock-amd64"
   - &base_build_atom_opengl_tag "base-1024-opengl-amd64"
-  - &base_build_atom_cuda_tag "base-1024-cuda-amd64"
-  - &base_build_atom_opengl_cuda_tag "base-1024-opengl-cuda-amd64"
+  - &base_build_atom_cuda_tag "base-1058-cuda-amd64"
+  - &base_build_atom_opengl_cuda_tag "base-1058-opengl-cuda-amd64"
+  - &base_build_atom_opengl_cuda_vnc_tag "base-1058-opengl-cuda-vnc-amd64"
   - &base_build_atom_aarch64_tag "base-1024-stock-aarch64"
   - &base_build_tags
       source_tag:
@@ -184,6 +185,7 @@ aliases:
         - *base_build_atom_opengl_tag
         - *base_build_atom_cuda_tag
         - *base_build_atom_opengl_cuda_tag
+        - *base_build_atom_opengl_cuda_vnc_tag
         - *base_build_atom_aarch64_tag
 
   # Helpful alias when building bases using additional Dockerfiles

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,7 @@ aliases:
   # Base Build Matrix
   - &base_matrix
       parameters:
-        variant: ["stock", "opengl", "cuda", "opengl-cuda"]
+        variant: ["stock", "opengl", "cuda", "opengl-cuda", "opencv"]
         platform: ["amd64", "aarch64"]
       exclude:
         - variant: "opengl"
@@ -376,16 +376,12 @@ commands:
   build_atom_base_test:
     parameters:
       <<: *build_atom_variant_shared_params
-      input_tag:
-        type: string
-        default: base-build-<< pipeline.number >>
-
     steps:
 
       # Build the atom variant with the base
       - build_atom_with_nucleus_variant:
           << : *build_atom_variant_shared_mapping
-          base_tag: << parameters.input_tag >>-<< pipeline.number >>-<< parameters.variant >>-<< parameters.platform >>
+          base_tag: base-build-<< pipeline.number >>-<< parameters.variant >>-<< parameters.platform >>
           production_image: << parameters.base_repo >>:<< parameters.base_tag >>
 
   build_dockerfile_atom_base:
@@ -394,13 +390,9 @@ commands:
       file:
         type: string
         default: Dockerfile-base
-      image_tag:
-        type: string
       prev_image:
         type: string
       prev_tag:
-        type: string
-      cache_tag:
         type: string
     steps:
 
@@ -410,12 +402,12 @@ commands:
           variant: << parameters.variant >>
           platform: << parameters.platform >>
           image_name: << pipeline.parameters.dockerhub_org >>/<< pipeline.parameters.atom_repo_name >>
-          image_tag: << parameters.image_tag >>-<< pipeline.number >>
+          image_tag: base-build-<< pipeline.number >>
           build_args: >-
             --build-arg
             BASE_IMAGE=<< parameters.prev_image >>:<< parameters.prev_tag >>
             << parameters.build_args >>
-          cache_tag: << parameters.cache_tag >>
+          cache_tag: cache-base
           cache_repo: << parameters.cache_repo >>
           no_output_timeout: 3h
 
@@ -426,7 +418,7 @@ commands:
           variant: << parameters.variant >>
           platform: << parameters.platform >>
 
-  build_atom_base:
+  build_atom_base_variant:
     parameters:
       << : *build_atom_variant_shared_params
     steps:
@@ -435,107 +427,36 @@ commands:
       - build_dockerfile_atom_base:
           << : *build_atom_variant_shared_mapping
           file: Dockerfile-base
-          image_tag: base-build
           prev_image: << parameters.base_repo >>
           prev_tag: << parameters.base_tag >>
-          cache_tag: cache-base
 
-  build_atom_base_add_vnc:
+      # Push and Test
+      - build_atom_base_test:
+          << : *build_atom_variant_shared_mapping
+          base_repo: << parameters.base_repo >>
+          base_tag: << parameters.base_tag >>
+
+  build_atom_base_variant_add:
     parameters:
       << : *build_atom_variant_shared_params
-      input_tag:
-        type: string
+    file:
+      type: string
+    prev:
+      type: string
+      default: ""
     steps:
 
-      # Build the vanilla base
+        # Build the vanilla base
       - build_dockerfile_atom_base:
           << : *build_atom_variant_shared_mapping
           << : *build_atom_base_add_shared_mapping
-          file: Dockerfile-vnc
-          image_tag: base-build-with-vnc
-          cache_tag: cache-base-with-vnc
-
-  build_atom_base_add_opengl:
-    parameters:
-      << : *build_atom_variant_shared_params
-      input_tag:
-        type: string
-    steps:
-
-      # Build the vanilla base
-      - build_dockerfile_atom_base:
-          << : *build_atom_variant_shared_mapping
-          << : *build_atom_base_add_shared_mapping
-          file: Dockerfile-opengl
-          image_tag: base-build-with-opengl
-          cache_tag: cache-base-with-opengl
-
-  build_atom_base_variant:
-    parameters:
-      << : *build_atom_variant_shared_params
-    steps:
-
-      # Build the vanilla base
-      - build_atom_base:
-          << : *build_atom_variant_shared_mapping
-          base_repo: << parameters.base_repo >>
-          base_tag: << parameters.base_tag >>
+          file: << parameters.file >>
+          prev_image: << pipeline.parameters.atom_repo_name >>
+          prev_tag: base-build-<< pipeline.number >>-<< parameters.prev >>-<< parameters.platform >>
 
       # Push and Test
       - build_atom_base_test:
           << : *build_atom_variant_shared_mapping
-          input_tag: base-build
-          base_repo: << parameters.base_repo >>
-          base_tag: << parameters.base_tag >>
-
-  build_atom_base_variant_with_vnc:
-    parameters:
-      << : *build_atom_variant_shared_params
-    steps:
-
-      # Build the vanilla base
-      - build_atom_base:
-          << : *build_atom_variant_shared_mapping
-          base_repo: << parameters.base_repo >>
-          base_tag: << parameters.base_tag >>
-
-      # Add in the VNC
-      - build_atom_base_add_vnc:
-          << : *build_atom_variant_shared_mapping
-          input_tag: base-build
-
-      # Push and Test
-      - build_atom_base_test:
-          << : *build_atom_variant_shared_mapping
-          input_tag: base-build-with-vnc
-          base_repo: << parameters.base_repo >>
-          base_tag: << parameters.base_tag >>
-
-  build_atom_base_variant_with_vnc_opengl:
-    parameters:
-      << : *build_atom_variant_shared_params
-    steps:
-
-      # Build the vanilla base
-      - build_atom_base:
-          << : *build_atom_variant_shared_mapping
-          base_repo: << parameters.base_repo >>
-          base_tag: << parameters.base_tag >>
-
-      # Add in the VNC
-      - build_atom_base_add_vnc:
-          << : *build_atom_variant_shared_mapping
-          input_tag: base-build
-
-      # Add in OpenGL
-      - build_atom_base_add_opengl:
-          << : *build_atom_variant_shared_mapping
-          input_tag: base-build-with-vnc
-
-      # Push and Test
-      - build_atom_base_test:
-          << : *build_atom_variant_shared_mapping
-          input_tag: base-build-with-opengl
           base_repo: << parameters.base_repo >>
           base_tag: << parameters.base_tag >>
 
@@ -582,26 +503,14 @@ jobs:
           base_repo: << parameters.base_repo >>
           base_tag: << parameters.base_tag >>
 
-  build-base-with-vnc:
+  build-base-add:
     parameters:
       << : *build_atom_variant_shared_params
     executor: atom/build-ubuntu
     resource_class: large
     steps:
       - build_shared_init
-      - build_atom_base_variant_with_vnc:
-          << : *build_atom_variant_shared_mapping
-          base_repo: << parameters.base_repo >>
-          base_tag: << parameters.base_tag >>
-
-  build-base-with-vnc-opengl:
-    parameters:
-      << : *build_atom_variant_shared_params
-    executor: atom/build-ubuntu
-    resource_class: large
-    steps:
-      - build_shared_init
-      - build_atom_base_variant_with_vnc_opengl:
+      - build_atom_base_variant_add:
           << : *build_atom_variant_shared_mapping
           base_repo: << parameters.base_repo >>
           base_tag: << parameters.base_tag >>
@@ -990,7 +899,9 @@ workflows:
   base-build:
     jobs:
 
-      # Build base images
+      #
+      # Stock AMD64 base and variants
+      #
       - build-base:
           name: "build-base-<< matrix.variant >>-<< matrix.platform >>"
           matrix:
@@ -1004,7 +915,122 @@ workflows:
               only:
                 - /.*-build-base-all/
                 - /.*-build-base-atom/
+                - /.*-build-base-opencv/
 
+      - build-base-add:
+          name: "build-base-<< matrix.variant >>-<< matrix.platform >>"
+          matrix:
+            parameters:
+              variant: [ opencv ]
+              platform: [ amd64 ]
+              prev: [ stock ]
+          file: Dockerfile-opencv
+          base_repo: debian
+          base_tag: buster-slim
+          requires:
+            - build-base-<< matrix.prev >>-<< matrix.platform >>
+          filters:
+            branches:
+              only:
+                - /.*-build-base-all/
+                - /.*-build-base-opencv/
+
+      #
+      # Cuda AMD64 base and variants
+      #
+
+      - build-base:
+          name: "build-base-cuda-<< matrix.platform >>"
+          matrix:
+            parameters:
+              variant: [ cuda ]
+              platform: [ amd64 ]
+          base_repo: nvidia/cuda
+          base_tag: 10.2-cudnn7-runtime-ubuntu18.04
+          filters:
+            branches:
+              only:
+                - /.*-build-base-all/
+                - /.*-build-base-cuda/
+                - /.*-build-base-opengl-cuda/
+
+      - build-base-add:
+          name: "build-base-<< matrix.variant >>-<< matrix.platform >>"
+          matrix:
+            parameters:
+              variant: [ opengl-cuda ]
+              platform: [ amd64 ]
+              prev: [ cuda ]
+          file: Dockerfile-opengl
+          base_repo: nvidia/cuda
+          base_tag: 10.2-cudnn7-runtime-ubuntu18.04
+          requires:
+            - build-base-<< matrix.prev >>-<< matrix.platform >>
+          filters:
+            branches:
+              only:
+                - /.*-build-base-all/
+                - /.*-build-base-opengl-cuda/
+                - /.*-build-base-opengl-cuda-vnc/
+
+      - build-base-add:
+          name: "build-base-<< matrix.variant >>-<< matrix.platform >>"
+          matrix:
+            parameters:
+              variant: [opengl-cuda-vnc]
+              platform: [ amd64 ]
+              prev: [ opengl-cuda ]
+          file: Dockerfile-vnc
+          base_repo: nvidia/cuda
+          base_tag: 10.2-cudnn7-runtime-ubuntu18.04
+          requires:
+            - build-base-opengl-cuda-<< matrix.platform >>
+          filters:
+            branches:
+              only:
+                - /.*-build-base-all/
+                - /.*-build-base-opengl-cuda-vnc/
+
+      #
+      # OpenGL AMD64 base and variants
+      #
+
+      - build-base:
+          name: "build-base-<< matrix.variant >>-<< matrix.platform >>"
+          matrix:
+            parameters:
+              variant: [ opengl ]
+              platform: [ amd64 ]
+          base_repo: nvidia/opengl
+          base_tag: 1.0-glvnd-runtime-ubuntu18.04
+          filters:
+            branches:
+              only:
+                - /.*-build-base-all/
+                - /.*-build-base-opengl/
+                - /.*-build-base-opengl-vnc/
+
+      - build-base-add:
+          name: "build-base-<< matrix.variant >>-<< matrix.platform >>"
+          matrix:
+            parameters:
+              variant: [ opengl-vnc ]
+              platform: [ amd64 ]
+              prev: [ opengl ]
+          file: Dockerfile-vnc
+          base_repo: nvidia/opengl
+          base_tag: 1.0-glvnd-runtime-ubuntu18.04
+          requires:
+            - build-base-<< prev >>-<< matrix.platform >>
+          filters:
+            branches:
+              only:
+                - /.*-build-base-all/
+                - /.*-build-base-opengl-vnc/
+
+      #
+      # Stock AARCH64 base + variants
+      #
       - build-base:
           name: "build-base-<< matrix.variant >>-<< matrix.platform >>"
           matrix:
@@ -1020,48 +1046,28 @@ workflows:
               only:
                 - /.*-build-base-all/
                 - /.*-build-base-aarch64/
+                - /.*-build-base-opencv/
 
-      - build-base-with-vnc:
+      - build-base-add:
           name: "build-base-<< matrix.variant >>-<< matrix.platform >>"
           matrix:
             parameters:
-              variant: [ opengl ]
-              platform: [ amd64 ]
-          base_repo: nvidia/opengl
-          base_tag: 1.0-glvnd-runtime-ubuntu18.04
+              variant: [ opencv ]
+              platform: [ aarch64 ]
+              prev: [ stock ]
+          file: Dockerfile-opencv
+          base_repo: debian
+          base_tag: buster-slim
+          build_args: "--build-arg ARCH=aarch64"
+          test_valgrind: false
+          requires:
+            - build-base-<< matrix.prev >>-<< matrix.platform >>
           filters:
             branches:
               only:
                 - /.*-build-base-all/
-                - /.*-build-base-opengl/
+                - /.*-build-base-opencv/
 
-      - build-base:
-          name: "build-base-<< matrix.variant >>-<< matrix.platform >>"
-          matrix:
-            parameters:
-              variant: [ cuda ]
-              platform: [ amd64 ]
-          base_repo: nvidia/cuda
-          base_tag: 10.2-cudnn7-runtime-ubuntu18.04
-          filters:
-            branches:
-              only:
-                - /.*-build-base-all/
-                - /.*-build-base-cuda/
-
-      - build-base-with-vnc-opengl:
-          name: "build-base-<< matrix.variant >>-<< matrix.platform >>"
-          matrix:
-            parameters:
-              variant: [ opengl-cuda ]
-              platform: [ amd64 ]
-          base_repo: nvidia/cuda
-          base_tag: 10.2-cudnn7-runtime-ubuntu18.04
-          filters:
-            branches:
-              only:
-                - /.*-build-base-all/
-                - /.*-build-base-opengl-cuda/
 
       # Deploy base images. Don't need branch filters since they depend
       # on base builds with the branch filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -951,6 +951,7 @@ workflows:
           file: Dockerfile-opencv
           base_repo: debian
           base_tag: buster-slim
+          build_args: "--build-arg PRODUCTION_IMAGE=debian:buster-slim"
           filters:
             branches:
               only:
@@ -1066,7 +1067,7 @@ workflows:
           file: Dockerfile-opencv
           base_repo: debian
           base_tag: buster-slim
-          build_args: "--build-arg ARCH=aarch64"
+          build_args: "--build-arg ARCH=aarch64 --build-arg PRODUCTION_IMAGE=debian:buster-slim"
           test_valgrind: false
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,17 @@ aliases:
   # Helpful alias when building bases using additional Dockerfiles
   - &build_atom_base_add_shared_mapping
       prev_image: << pipeline.parameters.dockerhub_org >>/<< pipeline.parameters.atom_repo_name >>
-      prev_tag: << parameters.input_tag >>-<< pipeline.number >>-<< parameters.variant >>-<< parameters.platform >>
+      prev_tag: base-build-<< pipeline.number >>-<< parameters.variant >>-<< parameters.platform >>
+
+  # Shared requirement when building with build-base
+  - &build_atom_base_shared
+      name: "build-base-<< matrix.variant >>-<< matrix.platform >>"
+
+  # Shared requirement when building with build-base-add
+  - &build_atom_base_add_shared
+      name: "build-base-<< matrix.variant >>-<< matrix.platform >>"
+      requires:
+        - "build-base-<< matrix.previous >>-<< matrix.platform >>"
 
   #
   # Docs build shared info
@@ -414,7 +424,7 @@ commands:
       # Push build image
       - atom/push_image_variant:
           target_image: << pipeline.parameters.dockerhub_org >>/<< pipeline.parameters.atom_repo_name >>
-          target_tag: << parameters.image_tag >>-<< pipeline.number >>
+          target_tag: base-build-<< pipeline.number >>
           variant: << parameters.variant >>
           platform: << parameters.platform >>
 
@@ -439,11 +449,10 @@ commands:
   build_atom_base_variant_add:
     parameters:
       << : *build_atom_variant_shared_params
-    file:
-      type: string
-    prev:
-      type: string
-      default: ""
+      file:
+        type: string
+      previous:
+        type: string
     steps:
 
         # Build the vanilla base
@@ -452,7 +461,7 @@ commands:
           << : *build_atom_base_add_shared_mapping
           file: << parameters.file >>
           prev_image: << pipeline.parameters.atom_repo_name >>
-          prev_tag: base-build-<< pipeline.number >>-<< parameters.prev >>-<< parameters.platform >>
+          prev_tag: base-build-<< pipeline.number >>-<< parameters.previous >>-<< parameters.platform >>
 
       # Push and Test
       - build_atom_base_test:
@@ -506,12 +515,18 @@ jobs:
   build-base-add:
     parameters:
       << : *build_atom_variant_shared_params
+      file:
+        type: string
+      previous:
+        type: string
     executor: atom/build-ubuntu
     resource_class: large
     steps:
       - build_shared_init
       - build_atom_base_variant_add:
           << : *build_atom_variant_shared_mapping
+          file: << parameters.file >>
+          previous: << parameters.previous >>
           base_repo: << parameters.base_repo >>
           base_tag: << parameters.base_tag >>
 
@@ -903,7 +918,7 @@ workflows:
       # Stock AMD64 base and variants
       #
       - build-base:
-          name: "build-base-<< matrix.variant >>-<< matrix.platform >>"
+          << : *build_atom_base_shared
           matrix:
             parameters:
               variant: [ stock ]
@@ -916,31 +931,31 @@ workflows:
                 - /.*-build-base-all/
                 - /.*-build-base-atom/
                 - /.*-build-base-opencv/
+                - /.*-build-base-opencv-amd64/
 
       - build-base-add:
-          name: "build-base-<< matrix.variant >>-<< matrix.platform >>"
+          << : *build_atom_base_add_shared
           matrix:
             parameters:
               variant: [ opencv ]
               platform: [ amd64 ]
-              prev: [ stock ]
+              previous: [ stock ]
           file: Dockerfile-opencv
           base_repo: debian
           base_tag: buster-slim
-          requires:
-            - build-base-<< matrix.prev >>-<< matrix.platform >>
           filters:
             branches:
               only:
                 - /.*-build-base-all/
                 - /.*-build-base-opencv/
+                - /.*-build-base-opencv-amd64/
 
       #
       # Cuda AMD64 base and variants
       #
 
       - build-base:
-          name: "build-base-cuda-<< matrix.platform >>"
+          << : *build_atom_base_shared
           matrix:
             parameters:
               variant: [ cuda ]
@@ -955,48 +970,34 @@ workflows:
                 - /.*-build-base-opengl-cuda/
 
       - build-base-add:
-          name: "build-base-<< matrix.variant >>-<< matrix.platform >>"
+          << : *build_atom_base_add_shared
           matrix:
             parameters:
-              variant: [ opengl-cuda ]
+              variant: [ opengl-cuda, opengl-cuda-vnc ]
               platform: [ amd64 ]
-              prev: [ cuda ]
+              previous: [ cuda, opengl-cuda ]
+            exclude:
+              - variant: opengl-cuda
+                previous: opengl-cuda
+                platform: amd64
+              - variant: opengl-cuda-vnc
+                previous: cuda
+                platform: amd64
           file: Dockerfile-opengl
           base_repo: nvidia/cuda
           base_tag: 10.2-cudnn7-runtime-ubuntu18.04
-          requires:
-            - build-base-<< matrix.prev >>-<< matrix.platform >>
           filters:
             branches:
               only:
                 - /.*-build-base-all/
                 - /.*-build-base-opengl-cuda/
-                - /.*-build-base-opengl-cuda-vnc/
-
-      - build-base-add:
-          name: "build-base-<< matrix.variant >>-<< matrix.platform >>"
-          matrix:
-            parameters:
-              variant: [opengl-cuda-vnc]
-              platform: [ amd64 ]
-              prev: [ opengl-cuda ]
-          file: Dockerfile-vnc
-          base_repo: nvidia/cuda
-          base_tag: 10.2-cudnn7-runtime-ubuntu18.04
-          requires:
-            - build-base-opengl-cuda-<< matrix.platform >>
-          filters:
-            branches:
-              only:
-                - /.*-build-base-all/
-                - /.*-build-base-opengl-cuda-vnc/
 
       #
       # OpenGL AMD64 base and variants
       #
 
       - build-base:
-          name: "build-base-<< matrix.variant >>-<< matrix.platform >>"
+          << : *build_atom_base_shared
           matrix:
             parameters:
               variant: [ opengl ]
@@ -1011,17 +1012,15 @@ workflows:
                 - /.*-build-base-opengl-vnc/
 
       - build-base-add:
-          name: "build-base-<< matrix.variant >>-<< matrix.platform >>"
+          << : *build_atom_base_add_shared
           matrix:
             parameters:
               variant: [ opengl-vnc ]
               platform: [ amd64 ]
-              prev: [ opengl ]
+              previous: [ opengl ]
           file: Dockerfile-vnc
           base_repo: nvidia/opengl
           base_tag: 1.0-glvnd-runtime-ubuntu18.04
-          requires:
-            - build-base-<< prev >>-<< matrix.platform >>
           filters:
             branches:
               only:
@@ -1032,7 +1031,7 @@ workflows:
       # Stock AARCH64 base + variants
       #
       - build-base:
-          name: "build-base-<< matrix.variant >>-<< matrix.platform >>"
+          << : *build_atom_base_shared
           matrix:
             parameters:
               variant: [ stock ]
@@ -1047,26 +1046,26 @@ workflows:
                 - /.*-build-base-all/
                 - /.*-build-base-aarch64/
                 - /.*-build-base-opencv/
+                - /.*-build-base-opencv-aarch64/
 
       - build-base-add:
-          name: "build-base-<< matrix.variant >>-<< matrix.platform >>"
+          << : *build_atom_base_add_shared
           matrix:
             parameters:
               variant: [ opencv ]
               platform: [ aarch64 ]
-              prev: [ stock ]
+              previous: [ stock ]
           file: Dockerfile-opencv
           base_repo: debian
           base_tag: buster-slim
           build_args: "--build-arg ARCH=aarch64"
           test_valgrind: false
-          requires:
-            - build-base-<< matrix.prev >>-<< matrix.platform >>
           filters:
             branches:
               only:
                 - /.*-build-base-all/
                 - /.*-build-base-opencv/
+                - /.*-build-base-opencv-aarch64/
 
 
       # Deploy base images. Don't need branch filters since they depend

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -462,7 +462,7 @@ commands:
           << : *build_atom_variant_shared_mapping
           << : *build_atom_base_add_shared_mapping
           file: << parameters.file >>
-          prev_image: << pipeline.parameters.atom_repo_name >>
+          prev_image: << pipeline.parameters.dockerhub_org >>/<< pipeline.parameters.atom_repo_name >>
           prev_tag: base-build-<< pipeline.number >>-<< parameters.previous >>-<< parameters.platform >>
 
       # Push and Test
@@ -506,7 +506,7 @@ jobs:
     parameters:
       << : *build_atom_variant_shared_params
     executor: atom/build-ubuntu
-    resource_class: large
+    resource_class: medium
     steps:
       - build_shared_init
       - build_atom_base_variant:
@@ -522,7 +522,7 @@ jobs:
       previous:
         type: string
     executor: atom/build-ubuntu
-    resource_class: large
+    resource_class: medium
     steps:
       - build_shared_init
       - build_atom_base_variant_add:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,15 +109,21 @@ aliases:
   # Atom Build Matrix
   - &atom_matrix
       parameters:
-        variant: ["stock", "opengl-vnc", "cuda", "opengl-cuda-vnc"]
+        variant: ["stock", "opengl", "opengl-vnc", "cuda", "opengl-cuda", "opengl-cuda-vnc", "opencv"]
         platform: ["amd64", "aarch64"]
         component: ["atom", "nucleus"]
       exclude:
         # No opengl, CUDA, or opengl-cuda builds for AARCH64 atom
+        - variant: "opengl"
+          platform: "aarch64"
+          component: "atom"
         - variant: "opengl-vnc"
           platform: "aarch64"
           component: "atom"
         - variant: "cuda"
+          platform: "aarch64"
+          component: "atom"
+        - variant: "opengl-cuda"
           platform: "aarch64"
           component: "atom"
         - variant: "opengl-cuda-vnc"
@@ -134,6 +140,15 @@ aliases:
         - variant: "opengl-cuda-vnc"
           platform: "aarch64"
           component: "nucleus"
+        - variant: "opencv"
+          platform: "aarch64"
+          component: "nucleus"
+        - variant: "opengl"
+          platform: "aarch64"
+          component: "nucleus"
+        - variant: "opengl-cuda"
+          platform: "aarch64"
+          component: "nucleus"
 
         # No opengl, CUDA, or opengl-cuda builds for AMD64 nucleus
         - variant: "opengl-vnc"
@@ -145,6 +160,16 @@ aliases:
         - variant: "opengl-cuda-vnc"
           platform: "amd64"
           component: "nucleus"
+        - variant: "opencv"
+          platform: "amd64"
+          component: "nucleus"
+        - variant: "opengl"
+          platform: "amd64"
+          component: "nucleus"
+        - variant: "opengl-cuda"
+          platform: "amd64"
+          component: "nucleus"
+
 
   # Shared config around deployment logic
   - &atom_deploy_shared_mapping
@@ -175,22 +200,26 @@ aliases:
 
 
   # Base tags in use for the various builds
-  - &base_build_atom_tag "base-1024-stock-amd64"
-  - &base_build_atom_opengl_tag "base-1061-opengl-amd64"
-  - &base_build_atom_opengl_vnc_tag "base-1061-opengl-vnc-amd64"
-  - &base_build_atom_cuda_tag "base-1058-cuda-amd64"
-  - &base_build_atom_opengl_cuda_tag "base-1058-opengl-cuda-amd64"
-  - &base_build_atom_opengl_cuda_vnc_tag "base-1058-opengl-cuda-vnc-amd64"
-  - &base_build_atom_aarch64_tag "base-1024-stock-aarch64"
+  - &base_build_atom_stock_amd64_tag "base-1067-stock-amd64"
+  - &base_build_atom_opencv_amd64_tag "base-1067-opencv-amd64"
+  - &base_build_atom_opengl_amd64_tag "base-1067-opengl-amd64"
+  - &base_build_atom_opengl_vnc_amd64_tag "base-1067-opengl-vnc-amd64"
+  - &base_build_atom_cuda_amd64_tag "base-1067-cuda-amd64"
+  - &base_build_atom_opengl_cuda_amd64_tag "base-1067-opengl-cuda-amd64"
+  - &base_build_atom_opengl_cuda_vnc_amd64_tag "base-1067-opengl-cuda-vnc-amd64"
+  - &base_build_atom_stock_aarch64_tag "base-1067-stock-aarch64"
+  - &base_build_atom_opencv_aarch64_tag "base-1067-opencv-aarch64"
   - &base_build_tags
       source_tag:
-        - *base_build_atom_tag
-        - *base_build_atom_opengl_tag
-        - *base_build_atom_opengl_vnc_tag
-        - *base_build_atom_cuda_tag
-        - *base_build_atom_opengl_cuda_tag
-        - *base_build_atom_opengl_cuda_vnc_tag
-        - *base_build_atom_aarch64_tag
+        - *base_build_atom_stock_amd64_tag
+        - *base_build_atom_opencv_amd64_tag
+        - *base_build_atom_opengl_amd64_tag
+        - *base_build_atom_opengl_vnc_amd64_tag
+        - *base_build_atom_cuda_amd64_tag
+        - *base_build_atom_opengl_cuda_amd64_tag
+        - *base_build_atom_opengl_cuda_vnc_amd64_tag
+        - *base_build_atom_stock_aarch64_tag
+        - *base_build_atom_opencv_aarch64_tag
 
   # Helpful alias when building bases using additional Dockerfiles
   - &build_atom_base_add_shared_mapping
@@ -600,8 +629,10 @@ workflows:
       #   AMD64
       #     - stock
       #     - opengl
-      #     - opengl-cuda
+      #     - opengl-vnc
       #     - cuda
+      #     - opengl-cuda
+      #     - opengl-cuda-vnc
       #   AARCH64
       #     - stock
       #
@@ -617,7 +648,7 @@ workflows:
             parameters:
               variant: [ stock ]
               platform: [ amd64 ]
-          base_tag: *base_build_atom_tag
+          base_tag: *base_build_atom_stock_amd64_tag
           production_image: debian:buster-slim
           filters:
             tags:
@@ -627,14 +658,23 @@ workflows:
               ignore:
                 - /.*-build-base.*/
 
-      # AMD64 openGL
+      # AMD64 openGL + openGL-VNC
       - build-atom:
           name: *atom_matrix_build_job_name
           matrix:
             parameters:
-              variant: [ opengl-vnc ]
+              variant: [ opengl, opengl-vnc ]
               platform: [ amd64 ]
-          base_tag: *base_build_atom_opengl_tag
+              base_tag:
+                - *base_build_atom_opengl_amd64_tag
+                - *base_build_atom_opengl_vnc_amd64_tag
+            exclude:
+              - variant: opengl
+                platform: amd64
+                base_tag: *base_build_atom_opengl_vnc_amd64_tag
+              - variant: opengl-vnc
+                platform: amd64
+                base_tag: *base_build_atom_opengl_amd64_tag
           production_image: nvidia/opengl:1.0-glvnd-runtime-ubuntu18.04
           requires:
             - atom/check_flake8
@@ -646,14 +686,36 @@ workflows:
               ignore:
                 - /.*-build-base.*/
 
-      # AMD64 CUDA
+      # AMD64 CUDA, OpenGL-Cuda, OpenGL-Cuda-VNC
       - build-atom:
           name: *atom_matrix_build_job_name
           matrix:
             parameters:
-              variant: [ cuda ]
+              variant: [ cuda, opengl-cuda, opengl-cuda-vnc ]
               platform: [ amd64 ]
-          base_tag: *base_build_atom_cuda_tag
+              base_tag:
+                - *base_build_atom_cuda_amd64_tag
+                - *base_build_atom_opengl_cuda_amd64_tag
+                - *base_build_atom_opengl_cuda_vnc_amd64_tag
+            exclude:
+              - variant: cuda
+                platform: amd64
+                base_tag: *base_build_atom_opengl_cuda_amd64_tag
+              - variant: cuda
+                platform: amd64
+                base_tag: *base_build_atom_opengl_cuda_vnc_amd64_tag
+              - variant: opengl-cuda
+                platform: amd64
+                base_tag: *base_build_atom_cuda_amd64_tag
+              - variant: opengl-cuda
+                platform: amd64
+                base_tag: *base_build_atom_opengl_cuda_vnc_amd64_tag
+              - variant: opengl-cuda-vnc
+                platform: amd64
+                base_tag: *base_build_atom_cuda_amd64_tag
+              - variant: opengl-cuda-vnc
+                platform: amd64
+                base_tag: *base_build_atom_opengl_cuda_amd64_tag
           production_image: nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04
           requires:
             - atom/check_flake8
@@ -665,16 +727,16 @@ workflows:
               ignore:
                 - /.*-build-base.*/
 
-      # AMD64 OpenGL + CUDA
+      # AMD64 openCV
       - build-atom:
           name: *atom_matrix_build_job_name
           matrix:
             parameters:
-              variant: [ opengl-cuda-vnc ]
+              variant: [ opencv ]
               platform: [ amd64 ]
-          base_tag: *base_build_atom_opengl_cuda_tag
-          production_image: nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04
-          build_args: --build-arg INSTALL_OPENGL=y
+              base_tag:
+                - *base_build_atom_opencv_amd64_tag
+          production_image: debian:buster-slim
           requires:
             - atom/check_flake8
           filters:
@@ -696,7 +758,27 @@ workflows:
             parameters:
               variant: [ stock ]
               platform: [ aarch64 ]
-          base_tag: *base_build_atom_aarch64_tag
+          base_tag: *base_build_atom_stock_aarch64_tag
+          production_image: debian:buster-slim
+          test_valgrind: false
+          requires:
+            - atom/check_flake8
+          filters:
+            tags:
+              only:
+                - /.*/
+            branches:
+              ignore:
+                - /.*-build-base.*/
+
+      # AARCH64 OpenCV
+      - build-atom:
+          name: *atom_matrix_build_job_name
+          matrix:
+            parameters:
+              variant: [ opencv ]
+              platform: [ aarch64 ]
+          base_tag: *base_build_atom_opencv_aarch64_tag
           production_image: debian:buster-slim
           test_valgrind: false
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,7 @@ aliases:
   # Base Build Matrix
   - &base_matrix
       parameters:
-        variant: ["stock", "opengl", "cuda", "opengl-cuda", "opengl-cuda-vnc", "opencv"]
+        variant: ["stock", "opengl", "cuda", "opengl-cuda", "opengl-cuda-vnc", "opengl-vnc", "opencv"]
         platform: ["amd64", "aarch64"]
       exclude:
         - variant: "opengl"
@@ -169,6 +169,8 @@ aliases:
         - variant: "opengl-cuda"
           platform: "aarch64"
         - variant: "opengl-cuda-vnc"
+          platform: "aarch64"
+        - variant: "opengl-vnc"
           platform: "aarch64"
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -528,7 +528,7 @@ jobs:
       previous:
         type: string
     executor: atom/build-ubuntu
-    resource_class: medium
+    resource_class: large
     steps:
       - build_shared_init
       - build_atom_base_variant_add:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -632,7 +632,7 @@ workflows:
           name: *atom_matrix_build_job_name
           matrix:
             parameters:
-              variant: [ opengl ]
+              variant: [ opengl-vnc ]
               platform: [ amd64 ]
           base_tag: *base_build_atom_opengl_tag
           production_image: nvidia/opengl:1.0-glvnd-runtime-ubuntu18.04
@@ -670,7 +670,7 @@ workflows:
           name: *atom_matrix_build_job_name
           matrix:
             parameters:
-              variant: [ opengl-cuda ]
+              variant: [ opengl-cuda-vnc ]
               platform: [ amd64 ]
           base_tag: *base_build_atom_opengl_cuda_tag
           production_image: nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,40 +109,40 @@ aliases:
   # Atom Build Matrix
   - &atom_matrix
       parameters:
-        variant: ["stock", "opengl", "cuda", "opengl-cuda"]
+        variant: ["stock", "opengl-vnc", "cuda", "opengl-cuda-vnc"]
         platform: ["amd64", "aarch64"]
         component: ["atom", "nucleus"]
       exclude:
         # No opengl, CUDA, or opengl-cuda builds for AARCH64 atom
-        - variant: "opengl"
+        - variant: "opengl-vnc"
           platform: "aarch64"
           component: "atom"
         - variant: "cuda"
           platform: "aarch64"
           component: "atom"
-        - variant: "opengl-cuda"
+        - variant: "opengl-cuda-vnc"
           platform: "aarch64"
           component: "atom"
 
         # No opengl, CUDA, or opengl-cuda builds for AARCH64 nucleus
-        - variant: "opengl"
+        - variant: "opengl-vnc"
           platform: "aarch64"
           component: "nucleus"
         - variant: "cuda"
           platform: "aarch64"
           component: "nucleus"
-        - variant: "opengl-cuda"
+        - variant: "opengl-cuda-vnc"
           platform: "aarch64"
           component: "nucleus"
 
         # No opengl, CUDA, or opengl-cuda builds for AMD64 nucleus
-        - variant: "opengl"
+        - variant: "opengl-vnc"
           platform: "amd64"
           component: "nucleus"
         - variant: "cuda"
           platform: "amd64"
           component: "nucleus"
-        - variant: "opengl-cuda"
+        - variant: "opengl-cuda-vnc"
           platform: "amd64"
           component: "nucleus"
 
@@ -176,7 +176,8 @@ aliases:
 
   # Base tags in use for the various builds
   - &base_build_atom_tag "base-1024-stock-amd64"
-  - &base_build_atom_opengl_tag "base-1024-opengl-amd64"
+  - &base_build_atom_opengl_tag "base-1061-opengl-amd64"
+  - &base_build_atom_opengl_vnc_tag "base-1061-opengl-vnc-amd64"
   - &base_build_atom_cuda_tag "base-1058-cuda-amd64"
   - &base_build_atom_opengl_cuda_tag "base-1058-opengl-cuda-amd64"
   - &base_build_atom_opengl_cuda_vnc_tag "base-1058-opengl-cuda-vnc-amd64"
@@ -185,6 +186,7 @@ aliases:
       source_tag:
         - *base_build_atom_tag
         - *base_build_atom_opengl_tag
+        - *base_build_atom_opengl_vnc_tag
         - *base_build_atom_cuda_tag
         - *base_build_atom_opengl_cuda_tag
         - *base_build_atom_opengl_cuda_vnc_tag

--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "third-party/opencv"]
 	path = third-party/opencv
 	url = git@github.com:opencv/opencv.git
+[submodule "languages/python/third-party/Pillow"]
+	path = languages/python/third-party/Pillow
+	url = git@github.com:python-pillow/Pillow.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "third-party/redis"]
 	path = third-party/redis
 	url = git@github.com:antirez/redis.git
+[submodule "third-party/opencv"]
+	path = third-party/opencv
+	url = git@github.com:opencv/opencv.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,7 @@ FROM $PRODUCTION_IMAGE as atom
 # Install python
 RUN apt-get update -y \
  && apt-get install -y --no-install-recommends apt-utils \
+                                               python3-minimal \
                                                python3-pip \
                                                libatomic1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,6 @@ FROM $PRODUCTION_IMAGE as atom
 # Install python
 RUN apt-get update -y \
  && apt-get install -y --no-install-recommends apt-utils \
-                                               python3-minimal \
                                                python3-pip \
                                                libatomic1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,12 +72,7 @@ RUN apt-get update -y \
  && apt-get install -y --no-install-recommends apt-utils \
                                                python3-minimal \
                                                python3-pip \
-                                               libatomic1 \
-                                               libglib2.0-0 \
-                                               libxml2 \
-                                               libgomp1 \
-                                               libgssapi-krb5-2
-
+                                               libatomic1
 
 
 # Copy contents of python virtualenv and activate

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,12 @@ RUN apt-get update -y \
  && apt-get install -y --no-install-recommends apt-utils \
                                                python3-minimal \
                                                python3-pip \
-                                               libatomic1
+                                               libatomic1 \
+                                               libglib2.0-0 \
+                                               libxml2 \
+                                               libgomp1 \
+                                               libgssapi-krb5-2
+
 
 
 # Copy contents of python virtualenv and activate
@@ -82,6 +87,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 # Copy C builds
 COPY --from=atom-source /usr/local/lib /usr/local/lib
 COPY --from=atom-source /usr/local/include /usr/local/include
+ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
 
 # Copy atom-cli
 COPY --from=atom-source /usr/local/bin/atom-cli /usr/local/bin/atom-cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 # Copy C builds
 COPY --from=atom-source /usr/local/lib /usr/local/lib
 COPY --from=atom-source /usr/local/include /usr/local/include
-ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
+ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
 
 # Copy atom-cli
 COPY --from=atom-source /usr/local/bin/atom-cli /usr/local/bin/atom-cli

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -46,7 +46,7 @@ RUN cd /atom/languages/c/third-party && make
 #
 
 # Create and activate python virtualenv
-RUN python3 -m venv /opt/venv
+RUN python3.7m -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
 

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -23,7 +23,6 @@ RUN apt-get update -y \
       libtool \
       cmake \
       build-essential \
-      python3-minimal \
       python3-pip \
       python3-venv \
       python3-dev \
@@ -46,7 +45,7 @@ RUN cd /atom/languages/c/third-party && make
 #
 
 # Create and activate python virtualenv
-RUN python3.7m -m venv /opt/venv
+RUN python3 -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
 

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -23,6 +23,7 @@ RUN apt-get update -y \
       libtool \
       cmake \
       build-essential \
+      python3-minimal \
       python3-pip \
       python3-venv \
       python3-dev \

--- a/Dockerfile-opencv
+++ b/Dockerfile-opencv
@@ -13,7 +13,13 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Install pre-requisites
 RUN apt-get update && apt-get install -y \
     zlib1g-dev \
-    libjpeg62-turbo-dev
+    libjpeg62-turbo-dev \
+    libpng-dev \
+    libtiff-dev \
+    libopenexr-dev \
+    libavcodec-dev \
+    libavformat-dev \
+    libswscale-dev
 
 # Install openCV + python3 bindings
 COPY ./third-party/opencv /atom/third-party/opencv

--- a/Dockerfile-opencv
+++ b/Dockerfile-opencv
@@ -10,6 +10,11 @@ FROM ${BASE_IMAGE} as with-opencv
 ARG ARCH=x86_64
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Get list of pre-existing libraries so that we can copy over the
+#   ones that get added in the apt-get process when done
+RUN ls /usr/lib/x86_64-linux-gnu/ > /tmp/existing_libs.txt && \
+    ls /lib/x86_64-linux-gnu/ >> /tmp/existing_libs.txt
+
 # Install pre-requisites
 RUN apt-get update && apt-get install -y \
     zlib1g-dev \
@@ -45,15 +50,8 @@ RUN MAX_CONCURRENCY=8 python3 setup.py install
 
 # Copy all dependencies over to /usr/local/lib so they get
 #   copied into the production image
-RUN ldd /usr/local/lib/libopencv_* \
-    | grep "=> /" \
-    | awk '{print $3}' \
-    | grep -v libopencv \
-    | grep -v libc \
-    | grep -v libm \
-    | grep -v libstdc++ \
-    | grep -v libdl \
-    | grep -v libpthread \
-    | grep -v libgcc_s \
-    | grep -v librt \
-    | xargs -I '{}' cp -v '{}' /usr/local/lib
+RUN ls /usr/lib/x86_64-linux-gnu/ > /tmp/new_libs.txt && \
+    ls /lib/x86_64-linux-gnu/ >> /tmp/new_libs.txt && \
+    sort /tmp/existing_libs.txt > /tmp/existing_libs_sorted.txt && \
+    sort /tmp/new_libs.txt > /tmp/new_libs_sorted.txt && \
+    diff --new-line-format="" --unchanged-line-format="" /tmp/new_libs_sorted.txt /tmp/existing_libs_sorted.txt | xargs -I {} cp -r /usr/lib/x86_64-linux-gnu/{} /usr/local/lib || cp -r /lib/x86_64-linux-gnu/{} /usr/local/lib

--- a/Dockerfile-opencv
+++ b/Dockerfile-opencv
@@ -42,3 +42,18 @@ RUN mkdir -p build && cd build && cmake \
 COPY ./languages/python/third-party/Pillow /atom/languages/python/third-party/Pillow
 WORKDIR /atom/languages/python/third-party/Pillow
 RUN MAX_CONCURRENCY=8 python3 setup.py install
+
+# Copy all dependencies over to /usr/local/lib so they get
+#   copied into the production image
+RUN ldd /usr/local/lib/libopencv_* \
+    | grep "=> /" \
+    | awk '{print $3}' \
+    | grep -v libopencv \
+    | grep -v libc \
+    | grep -v libm \
+    | grep -v libstdc++ \
+    | grep -v libdl \
+    | grep -v libpthread \
+    | grep -v libgcc_s \
+    | grep -v librt \
+    | xargs -I '{}' cp -v '{}' /usr/local/lib

--- a/Dockerfile-opencv
+++ b/Dockerfile-opencv
@@ -5,15 +5,11 @@
 ################################################################################
 
 ARG BASE_IMAGE
+ARG PRODUCTION_IMAGE
 FROM ${BASE_IMAGE} as with-opencv
 
 ARG ARCH=x86_64
 ARG DEBIAN_FRONTEND=noninteractive
-
-# Get list of pre-existing libraries so that we can copy over the
-#   ones that get added in the apt-get process when done
-RUN ls /usr/lib/x86_64-linux-gnu/ > /tmp/existing_libs.txt && \
-    ls /lib/x86_64-linux-gnu/ >> /tmp/existing_libs.txt
 
 # Install pre-requisites
 RUN apt-get update && apt-get install -y \
@@ -48,22 +44,21 @@ COPY ./languages/python/third-party/Pillow /atom/languages/python/third-party/Pi
 WORKDIR /atom/languages/python/third-party/Pillow
 RUN MAX_CONCURRENCY=8 python3 setup.py install
 
-# Copy all dependencies over to /usr/local/lib so they get
-#   copied into the production image. We need to do this since in the
-#   step to convert to production we minimize the size of the container
-#   by going back to the original base (typically debian:buster-slim) and
-#   just copying over /usr/local and other select things.
-RUN ls /usr/lib/x86_64-linux-gnu/ > /tmp/new_libs.txt && \
-    ls /lib/x86_64-linux-gnu/ >> /tmp/new_libs.txt && \
-    sort /tmp/existing_libs.txt > /tmp/existing_libs_sorted.txt && \
-    sort /tmp/new_libs.txt > /tmp/new_libs_sorted.txt && \
-    (diff --new-line-format="" --unchanged-line-format="" /tmp/new_libs_sorted.txt /tmp/existing_libs_sorted.txt > /tmp/diff_libs.txt || exit 0) && \
-    cd /usr/lib/x86_64-linux-gnu && ls libglib-2* >> /tmp/diff_libs.txt && \
-    cd /usr/lib/x86_64-linux-gnu && ls libgobject-2* >> /tmp/diff_libs.txt && \
-    cd /usr/lib/x86_64-linux-gnu && ls libgio-2* >> /tmp/diff_libs.txt && \
-    cd /usr/lib/x86_64-linux-gnu && ls libgssapi_krb5* >> /tmp/diff_libs.txt && \
-    cd /usr/lib/x86_64-linux-gnu && ls libgomp* >> /tmp/diff_libs.txt && \
-    cd /usr/lib/x86_64-linux-gnu && ls libxml2* >> /tmp/diff_libs.txt && \
-    cd /usr/lib/x86_64-linux-gnu && ls libicui18n* >> /tmp/diff_libs.txt && \
-    cd /usr/lib/x86_64-linux-gnu && ls libicuuc* >> /tmp/diff_libs.txt && \
-    xargs -a /tmp/diff_libs.txt -I {} cp -r /usr/lib/x86_64-linux-gnu/{} /usr/local/lib || cp -r /lib/x86_64-linux-gnu/{} /usr/local/lib
+RUN ldd /usr/local/lib/libopencv* | grep "=> /" | awk '{print $3}' | sort -u > /tmp/required_libs.txt
+
+FROM ${PRODUCTION_IMAGE} as no-deps
+
+RUN ls /lib/x86_64-linux-gnu/*.so* > /tmp/existing_libs.txt && \
+    ls /usr/lib/x86_64-linux-gnu/*.so* >> /tmp/existing_libs.txt
+
+FROM with-opencv as opencv-deps
+
+COPY --from=no-deps /tmp/existing_libs.txt /tmp/existing_libs.txt
+RUN diff --new-line-format="" --unchanged-line-format=""  /tmp/required_libs.txt /tmp/existing_libs.txt | grep -v /usr/local/lib > /tmp/libs_to_copy.txt
+RUN xargs -a /tmp/libs_to_copy.txt cp -L -t /usr/local/lib
+
+FROM ${BASE_IMAGE} as opencv-base
+
+COPY --from=opencv-deps /usr/local/lib /usr/local/lib
+COPY --from=opencv-deps /usr/local/include /usr/local/include
+COPY --from=opencv-deps /opt/venv /opt/venv

--- a/Dockerfile-opencv
+++ b/Dockerfile-opencv
@@ -57,4 +57,8 @@ RUN ls /usr/lib/x86_64-linux-gnu/ > /tmp/new_libs.txt && \
     ls /lib/x86_64-linux-gnu/ >> /tmp/new_libs.txt && \
     sort /tmp/existing_libs.txt > /tmp/existing_libs_sorted.txt && \
     sort /tmp/new_libs.txt > /tmp/new_libs_sorted.txt && \
-    diff --new-line-format="" --unchanged-line-format="" /tmp/new_libs_sorted.txt /tmp/existing_libs_sorted.txt | xargs -I {} cp -r /usr/lib/x86_64-linux-gnu/{} /usr/local/lib || cp -r /lib/x86_64-linux-gnu/{} /usr/local/lib
+    (diff --new-line-format="" --unchanged-line-format="" /tmp/new_libs_sorted.txt /tmp/existing_libs_sorted.txt > /tmp/diff_libs.txt || exit 0) && \
+    cd /usr/lib/x86_64-linux-gnu && ls libglib-2.0* >> /tmp/diff_libs.txt && \
+    cd /usr/lib/x86_64-linux-gnu && ls libgssapi_krb5* >> /tmp/diff_libs.txt && \
+    cd /usr/lib/x86_64-linux-gnu && ls libgomp* >> /tmp/diff_libs.txt && \
+    xargs -a /tmp/diff_libs.txt -I {} cp -r /usr/lib/x86_64-linux-gnu/{} /usr/local/lib || cp -r /lib/x86_64-linux-gnu/{} /usr/local/lib

--- a/Dockerfile-opencv
+++ b/Dockerfile-opencv
@@ -17,6 +17,7 @@ ARG PRODUCTION_IMAGE
 FROM ${BASE_IMAGE} as with-opencv
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG ARCH=x86_64
 
 # Install pre-requisites
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile-opencv
+++ b/Dockerfile-opencv
@@ -16,7 +16,6 @@ ARG PRODUCTION_IMAGE
 
 FROM ${BASE_IMAGE} as with-opencv
 
-ARG ARCH=x86_64
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install pre-requisites
@@ -60,8 +59,10 @@ RUN ldd /usr/local/lib/libopencv* | grep "=> /" | awk '{print $3}' | sort -u > /
 #
 FROM ${PRODUCTION_IMAGE} as no-deps
 
-RUN ls /lib/x86_64-linux-gnu/*.so* > /tmp/existing_libs.txt && \
-    ls /usr/lib/x86_64-linux-gnu/*.so* >> /tmp/existing_libs.txt
+ARG ARCH=x86_64
+
+RUN ls /lib/${ARCH}-linux-gnu/*.so* > /tmp/existing_libs.txt && \
+    ls /usr/lib/${ARCH}-linux-gnu/*.so* >> /tmp/existing_libs.txt
 
 #
 # Copy missing libraries from production into /usr/local/lib

--- a/Dockerfile-opencv
+++ b/Dockerfile-opencv
@@ -10,10 +10,14 @@ FROM ${BASE_IMAGE} as with-opencv
 ARG ARCH=x86_64
 ARG DEBIAN_FRONTEND=noninteractive
 
-COPY ./third-party/opencv /atom/third-party/opencv
-WORKDIR /atom/third-party/opencv
+# Install pre-requisites
+RUN apt-get update && apt-get install -y \
+    zlib1g-dev \
+    libjpeg62-turbo-dev
 
 # Install openCV + python3 bindings
+COPY ./third-party/opencv /atom/third-party/opencv
+WORKDIR /atom/third-party/opencv
 RUN mkdir -p build && cd build && cmake \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -26,3 +30,8 @@ RUN mkdir -p build && cd build && cmake \
     ../ && \
     make -j8 && \
     make install
+
+# Install Pillow (PIL) as that's also used frequently with opencv
+COPY ./languages/python/third-party/Pillow /atom/languages/python/third-party/Pillow
+WORKDIR /atom/languages/python/third-party/Pillow
+RUN MAX_CONCURRENCY=8 python3 setup.py install

--- a/Dockerfile-opencv
+++ b/Dockerfile-opencv
@@ -20,7 +20,8 @@ RUN apt-get update && apt-get install -y \
     libavcodec-dev \
     libavformat-dev \
     libswscale-dev \
-    libwebp-dev
+    libwebp-dev \
+    libprotobuf-dev
 
 # Install openCV + python3 bindings
 COPY ./third-party/opencv /atom/third-party/opencv

--- a/Dockerfile-opencv
+++ b/Dockerfile-opencv
@@ -1,0 +1,28 @@
+################################################################################
+#
+# Dockerfile for adding opencv into atom (or any debian-based image)
+#
+################################################################################
+
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} as with-opencv
+
+ARG ARCH=x86_64
+ARG DEBIAN_FRONTEND=noninteractive
+
+COPY ./third-party/opencv /atom/third-party/opencv
+WORKDIR /atom/third-party/opencv
+
+# Install openCV + python3 bindings
+RUN mkdir -p build && cd build && cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=/usr/local \
+    -DPYTHON3_EXECUTABLE=/opt/venv/bin/python3 \
+    -DPYTHON_INCLUDE_DIR=/usr/include/python3.7m \
+    -DPYTHON_INCLUDE_DIR2=/usr/include/${ARCH}-linux-gnu/python3.7m \
+    -DPYTHON_LIBRARY=/usr/lib/${ARCH}-linux-gnu/libpython3.7m.so \
+    -DPYTHON3_NUMPY_INCLUDE_DIRS=/opt/venv/lib/python3.7/site-packages/numpy-1.18.3-py3.7-linux-${ARCH}.egg/numpy/core/include \
+    -DOPENCV_PYTHON3_INSTALL_PATH=/opt/venv/lib/python3.7/site-packages \
+    ../ && \
+    make -j8 && \
+    make install

--- a/Dockerfile-opencv
+++ b/Dockerfile-opencv
@@ -58,7 +58,12 @@ RUN ls /usr/lib/x86_64-linux-gnu/ > /tmp/new_libs.txt && \
     sort /tmp/existing_libs.txt > /tmp/existing_libs_sorted.txt && \
     sort /tmp/new_libs.txt > /tmp/new_libs_sorted.txt && \
     (diff --new-line-format="" --unchanged-line-format="" /tmp/new_libs_sorted.txt /tmp/existing_libs_sorted.txt > /tmp/diff_libs.txt || exit 0) && \
-    cd /usr/lib/x86_64-linux-gnu && ls libglib-2.0* >> /tmp/diff_libs.txt && \
+    cd /usr/lib/x86_64-linux-gnu && ls libglib-2* >> /tmp/diff_libs.txt && \
+    cd /usr/lib/x86_64-linux-gnu && ls libgobject-2* >> /tmp/diff_libs.txt && \
+    cd /usr/lib/x86_64-linux-gnu && ls libgio-2* >> /tmp/diff_libs.txt && \
     cd /usr/lib/x86_64-linux-gnu && ls libgssapi_krb5* >> /tmp/diff_libs.txt && \
     cd /usr/lib/x86_64-linux-gnu && ls libgomp* >> /tmp/diff_libs.txt && \
+    cd /usr/lib/x86_64-linux-gnu && ls libxml2* >> /tmp/diff_libs.txt && \
+    cd /usr/lib/x86_64-linux-gnu && ls libicui18n* >> /tmp/diff_libs.txt && \
+    cd /usr/lib/x86_64-linux-gnu && ls libicuuc* >> /tmp/diff_libs.txt && \
     xargs -a /tmp/diff_libs.txt -I {} cp -r /usr/lib/x86_64-linux-gnu/{} /usr/local/lib || cp -r /lib/x86_64-linux-gnu/{} /usr/local/lib

--- a/Dockerfile-opencv
+++ b/Dockerfile-opencv
@@ -4,8 +4,16 @@
 #
 ################################################################################
 
+# Previous base we're going to build atop
 ARG BASE_IMAGE
+# Image this version of atom will ship with. Needed to determine which
+#   libraries we need to package up
 ARG PRODUCTION_IMAGE
+
+#
+# Build OpenCV
+#
+
 FROM ${BASE_IMAGE} as with-opencv
 
 ARG ARCH=x86_64
@@ -46,17 +54,30 @@ RUN MAX_CONCURRENCY=8 python3 setup.py install
 
 RUN ldd /usr/local/lib/libopencv* | grep "=> /" | awk '{print $3}' | sort -u > /tmp/required_libs.txt
 
+#
+# Determine libraries we'll ship with in production so we can see what's
+#   missing
+#
 FROM ${PRODUCTION_IMAGE} as no-deps
 
 RUN ls /lib/x86_64-linux-gnu/*.so* > /tmp/existing_libs.txt && \
     ls /usr/lib/x86_64-linux-gnu/*.so* >> /tmp/existing_libs.txt
 
+#
+# Copy missing libraries from production into /usr/local/lib
+#
 FROM with-opencv as opencv-deps
 
 COPY --from=no-deps /tmp/existing_libs.txt /tmp/existing_libs.txt
 RUN diff --new-line-format="" --unchanged-line-format=""  /tmp/required_libs.txt /tmp/existing_libs.txt | grep -v /usr/local/lib > /tmp/libs_to_copy.txt
 RUN xargs -a /tmp/libs_to_copy.txt cp -L -t /usr/local/lib
 
+#
+# Clean up and only ship the following folders:
+#   1. /usr/local/lib
+#   2. /usr/local/include
+#   3. /opt/venv
+#
 FROM ${BASE_IMAGE} as opencv-base
 
 COPY --from=opencv-deps /usr/local/lib /usr/local/lib

--- a/Dockerfile-opencv
+++ b/Dockerfile-opencv
@@ -49,7 +49,10 @@ WORKDIR /atom/languages/python/third-party/Pillow
 RUN MAX_CONCURRENCY=8 python3 setup.py install
 
 # Copy all dependencies over to /usr/local/lib so they get
-#   copied into the production image
+#   copied into the production image. We need to do this since in the
+#   step to convert to production we minimize the size of the container
+#   by going back to the original base (typically debian:buster-slim) and
+#   just copying over /usr/local and other select things.
 RUN ls /usr/lib/x86_64-linux-gnu/ > /tmp/new_libs.txt && \
     ls /lib/x86_64-linux-gnu/ >> /tmp/new_libs.txt && \
     sort /tmp/existing_libs.txt > /tmp/existing_libs_sorted.txt && \

--- a/Dockerfile-opencv
+++ b/Dockerfile-opencv
@@ -20,8 +20,7 @@ RUN apt-get update && apt-get install -y \
     libavcodec-dev \
     libavformat-dev \
     libswscale-dev \
-    libwebp-dev \
-    libprotobuf-dev
+    libwebp-dev
 
 # Install openCV + python3 bindings
 COPY ./third-party/opencv /atom/third-party/opencv

--- a/Dockerfile-opencv
+++ b/Dockerfile-opencv
@@ -19,7 +19,8 @@ RUN apt-get update && apt-get install -y \
     libopenexr-dev \
     libavcodec-dev \
     libavformat-dev \
-    libswscale-dev
+    libswscale-dev \
+    libwebp-dev
 
 # Install openCV + python3 bindings
 COPY ./third-party/opencv /atom/third-party/opencv

--- a/languages/python/tests/test_atom.py
+++ b/languages/python/tests/test_atom.py
@@ -61,7 +61,7 @@ class TestAtom:
         """
         proc = Process(target=caller.command_send, args=("test_responder", "test_cmd", 0,))
         proc.start()
-        data = caller._rclient.xread({caller._make_command_id("test_responder"): "$"}, block=100)
+        data = caller._rclient.xread({caller._make_command_id("test_responder"): "$"}, block=1000)
         proc.join()
         stream, msgs = data[0] #since there's only one stream
         assert stream == b"command:test_responder"

--- a/languages/python/tests/test_atom.py
+++ b/languages/python/tests/test_atom.py
@@ -267,7 +267,7 @@ class TestAtom:
         proc_responder_0.join()
         proc_responder_1.join()
         # Wait to give the caller time to handle all the data from the streams
-        thread_caller.join(0.5)
+        thread_caller.join(5.0)
         caller._rclient.delete("stream:responder_0:stream_0")
         caller._rclient.delete("stream:responder_1:stream_1")
         for i in range(20):

--- a/template/.circleci/docker-compose.yml
+++ b/template/.circleci/docker-compose.yml
@@ -1,0 +1,33 @@
+version: "3.2"
+
+services:
+
+  nucleus:
+    container_name: nucleus
+    image: ${NUCLEUS_IMAGE}
+    volumes:
+      - type: volume
+        source: shared
+        target: /shared
+        volume:
+          nocopy: true
+
+  test-container:
+    container_name: test-container
+    image: ${TEST_IMAGE}
+    volumes:
+      - type: volume
+        source: shared
+        target: /shared
+        volume:
+          nocopy: true
+      - ".:/test"
+    depends_on:
+      - "nucleus"
+    command: tail -f /dev/null
+
+volumes:
+  shared:
+    driver_opts:
+      type: tmpfs
+      device: tmpfs


### PR DESCRIPTION
- Adds in builds for `amd64` and `aarch64` with OpenCV `v4.3.0` installed
- Updates base image builds to chain subsequent builds + dockerfiles
- Adds new variants for `opencv`
- Any variant using VNC now has option with and without VNC.
- Updates docs.