### PR TITLE
atom.yml: fix bug in deploy

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -125,6 +125,12 @@ circleci orb publish promote elementaryrobotics/atom@dev:some-tag patch
 
 ### Release Notes
 
+#### [v0.1.8](https://circleci.com/orbs/registry/orb/elementaryrobotics/atom?version=0.1.8)
+
+##### New Features
+
+- Fixes bug in deploy when using different target and source images
+
 #### [v0.1.7](https://circleci.com/orbs/registry/orb/elementaryrobotics/atom?version=0.1.7)
 
 ##### New Features

--- a/.circleci/atom.yml
+++ b/.circleci/atom.yml
@@ -371,7 +371,7 @@ commands:
       - tag_and_push_image:
           source_image: << parameters.source_image >>
           source_tag: << parameters.source_tag >>-<< parameters.variant >>-<< parameters.platform >>
-          target_image: << parameters.source_image >>
+          target_image: << parameters.target_image >>
           target_tag: << parameters.target_tag >>-<< parameters.variant >>-<< parameters.platform >>
           target_tag_cmd: << parameters.target_tag_cmd >>
 
@@ -735,7 +735,7 @@ examples:
             target_image: << pipeline.parameters.dockerhub_repo >>
 
       orbs:
-        atom: elementaryrobotics/atom@0.1.7
+        atom: elementaryrobotics/atom@0.1.8
 
       workflows:
         version: 2
@@ -850,7 +850,7 @@ examples:
           default: elementaryrobotics/example-element
 
       orbs:
-        atom: elementaryrobotics/atom@0.1.7
+        atom: elementaryrobotics/atom@0.1.8
 
       workflows:
         version: 2


### PR DESCRIPTION
- Were using source image tag for target deploy. This
breaks when you use different repos which is a rare, but
real use case