### PR TITLE
Python element: add data_timeout_ms constructor arg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,7 +273,7 @@ commands:
     steps:
       - run:
           name: Python tests
-          command: docker exec -it -w /atom/languages/python/tests << parameters.container >> pytest -vv --durations=0 -k test_command_list_command --capture=tee-sys
+          command: docker exec -it -w /atom/languages/python/tests << parameters.container >> pytest -vv --durations=0 --capture=tee-sys
       - run:
           name: C tests
           command:  docker exec -it -w /atom/languages/c << parameters.container >> make test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,7 +273,7 @@ commands:
     steps:
       - run:
           name: Python tests
-          command: docker exec -it -w /atom/languages/python/tests << parameters.container >> pytest
+          command: docker exec -it -w /atom/languages/python/tests << parameters.container >> pytest -v --durations=0
       - run:
           name: C tests
           command:  docker exec -it -w /atom/languages/c << parameters.container >> make test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,7 +273,7 @@ commands:
     steps:
       - run:
           name: Python tests
-          command: docker exec -it -w /atom/languages/python/tests << parameters.container >> pytest -v --durations=0
+          command: docker exec -it -w /atom/languages/python/tests << parameters.container >> pytest -vv --durations=0 -k test_command_list_command --capture=tee-sys
       - run:
           name: C tests
           command:  docker exec -it -w /atom/languages/c << parameters.container >> make test

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -9,7 +9,7 @@ services:
       dockerfile: Dockerfile
       target: nucleus
       args:
-        BASE_IMAGE: elementaryrobotics/atom:base
+        BASE_IMAGE: elementaryrobotics/atom:v1.7.1-base-stock-amd64
     volumes:
       - type: volume
         source: shared
@@ -24,7 +24,7 @@ services:
       dockerfile: Dockerfile
       target: test
       args:
-        BASE_IMAGE: elementaryrobotics/atom:base
+        BASE_IMAGE: elementaryrobotics/atom:v1.7.1-base-stock-amd64
     volumes:
       - type: volume
         source: shared

--- a/languages/python/atom/element.py
+++ b/languages/python/atom/element.py
@@ -64,6 +64,7 @@ class Element:
         self._timed_out = False
         self._pid = os.getpid()
         self._cleaned_up = False
+        self.processes = []
         try:
             if host is not None:
                 self._host = host

--- a/languages/python/atom/element.py
+++ b/languages/python/atom/element.py
@@ -206,6 +206,7 @@ class Element:
         try:
             self._rclient.delete(self._make_response_id(self.name))
             self._rclient.delete(self._make_command_id(self.name))
+            self._rclient.delete(self._make_consumer_group_counter(self.name))
         except redis.exceptions.RedisError:
             raise Exception("Could not connect to nucleus!")
 

--- a/languages/python/atom/element.py
+++ b/languages/python/atom/element.py
@@ -613,7 +613,7 @@ class Element:
 
         self.processes = []
         for i in range(n_procs):
-            p = Process(target=self._command_loop, args=(self._command_loop_shutdown,))
+            p = Process(target=self._command_loop, args=(self._command_loop_shutdown,), kwargs={'read_block_ms' : read_block_ms})
             p.start()
             self.processes.append(p)
 
@@ -650,7 +650,7 @@ class Element:
             self._clean_up_streams()
         return result
 
-    def _command_loop(self, shutdown_event, read_block_ms=10000):
+    def _command_loop(self, shutdown_event, read_block_ms=1000):
         if hasattr(self, '_host'):
             _rclient = redis.StrictRedis(host=self._host, port=self._port)
         else:

--- a/languages/python/atom/element.py
+++ b/languages/python/atom/element.py
@@ -618,8 +618,7 @@ class Element:
             self.processes.append(p)
 
         if block:
-            for p in self.processes:
-                p.join()
+            self._command_loop_join()
 
     def _increment_command_group_counter(self, _pipe):
         """Incremeents reference counter for element stream collection"""
@@ -838,9 +837,16 @@ class Element:
                     _pipe=_pipe
                 )
 
-    def command_loop_shutdown(self):
+    def _command_loop_join(self):
+        """Waits for all threads from command loop to be finished"""
+        for p in self.processes:
+            p.join()
+
+    def command_loop_shutdown(self, block=False):
         """Triggers graceful exit of command loop"""
         self._command_loop_shutdown.set()
+        if block:
+            self._command_loop_join()
 
     def command_send(self,
                      element_name,


### PR DESCRIPTION
This argument will enforce that after we have established
a connection with the remote redis and we have sent it a command
we will wait for no longer than this number of milliseconds for data.

NOTE: This timeout is above and supersedes any timeouts set by
blocking redis calls, i.e. if you're using a N millisecond blocking
redis call you MUST instantiate your element with a data_timeout_ms
slightly greater than N. If data_timeout_ms is less than N the socket
will time out during the valid redis blocking window. This is by
design and desirable as we want to use this data_timeout_ms on the
linux/TCP socket level s.t. we can detect failed network connections.

The default timeout is 5s as there are not many blocking calls >5s
in known codebases. It's also generally recommended to implement
long-blocks for data with 1s blocks + polls and super long blocks
are generally not advised.

-----------------------------------------------------------------------------------------------

After implementing the above, this PR further contains:

1. Improvement to tests: Tests now clear redis keys at beginning and check to make sure all keys cleaned up at end.
2. Bugfix of leak of consumer group ID keys when implementing (1)
3. Improvement to tests: Tests now standardize around using a single env var for the redis host, port + socket s.t. we can easily change these in additional tests
4. Improvement to tests: Tests now standardize on single element creation/launch/cleanup process that ensures all elements are using the correct settings from (3) and ensures all element destructors are called before the key check from (1)
5. Adds the ability to call the functionality of `__del__` on an element without calling `__del__`. This was needed for (1) since the timing of the garbage collector was not predictable/reliable enough and/or the fact that calling `del` on an element just decrements a reference count was stopping us from ensuring our cleanup functions were being called for (1)
6. Adds the ability to call `command_loop_shutdown(block=True)` for Elements whose command loop was started with `block=False`.
7. Improvement to tests: Tests now, when creating an element using (4) by default will call `wait_for_element_healthy` on that element. This fixes a bug where ARM tests were hanging intermittently due to a race condition here from not checking to see that elements were healthy.
8. Fixes a bug in `command_loop` where the `read_block_ms` was not being passed from `command_loop` to `_command_loop`. Changed the default value across the board here to 1000ms. This is actually quite important as with the new 5s socket timeout from the main portion of this PR we would start to see socket timeouts quicker than XREAD timeouts in the command loop which would not be ideal.
9. Automatic whitespace deletion for unnecessary whitespace due to my `sublime-text` settings. I would have thought this would have been caught by our style checker, will file a separate issue for how we had this unnecessary whitespace in the codebase in the first place. 
10. Improvements to output logs when running pytest. We will now see individual pass/fail for each tests, length of tests ordered by longest to shortest when complete and stdout logs.
11. Bugfix in the developer `docker-compose` file as the `base` tag is no longer used/relevant. Hardcoded a decent base for now, will file a separate issue to get the `base` tag back to being `auto-deployed`. 
12. Reduction in Python unit test runtime -- same tests, 30s vs 2m on AMD64 due to improving timeouts and join()s