### PR TITLE
Deduplicate log messages

### DIFF
--- a/languages/python/atom/element.py
+++ b/languages/python/atom/element.py
@@ -211,7 +211,7 @@ class Element:
             )
             rfh.setFormatter(formatter)
             logger.addHandler(rfh)
-            self.logger = logging.LoggerAdapter(logger, extra)
+            logger = logging.LoggerAdapter(logger, extra)
 
             #
             # Set up log level
@@ -220,7 +220,9 @@ class Element:
             numeric_level = getattr(logging, loglevel.upper(), None)
             if not isinstance(numeric_level, int):
                 loglevel = LOG_DEFAULT_LEVEL
-            self.logger.setLevel(loglevel)
+            logger.setLevel(loglevel)
+
+        self.logger = logger
 
         # For now, only enable metrics if turned on in an environment flag
         if os.getenv("ATOM_USE_METRICS", "FALSE") == "TRUE":

--- a/languages/python/atom/element.py
+++ b/languages/python/atom/element.py
@@ -198,7 +198,7 @@ class Element:
         #
         # Set up logger
         #
-        self.logger = self._get_atom_logger(self.name)
+        self.logger = self._get_atom_logger()
 
         # For now, only enable metrics if turned on in an environment flag
         if os.getenv("ATOM_USE_METRICS", "FALSE") == "TRUE":
@@ -368,12 +368,12 @@ class Element:
 
         self.logger.info("Element initialized.")
 
-    def _get_atom_logger(self, name):
+    def _get_atom_logger(self):
         # Avoid redefining the logger if it already exists
-        if loggers.get(name):
-            return loggers.get(name)
+        if self.name in loggers:
+            return loggers.get(self.name)
         else:
-            logger = logging.getLogger(name)
+            logger = logging.getLogger(self.name)
             try:
                 rfh = logging.handlers.RotatingFileHandler(
                     f"{ATOM_LOG_DIR}{self.name}.log", maxBytes=ATOM_LOG_FILE_SIZE
@@ -396,7 +396,7 @@ class Element:
                 loglevel = LOG_DEFAULT_LEVEL
             logger.setLevel(loglevel)
 
-            loggers.update(dict(name=logger))
+            loggers[self.name] = logger
             return logger
 
     def __repr__(self):

--- a/languages/python/atom/element.py
+++ b/languages/python/atom/element.py
@@ -209,7 +209,7 @@ class Element:
         )
         rfh.setFormatter(formatter)
         logger.addHandler(rfh)
-        logger = logging.LoggerAdapter(logger, extra)
+        self.logger = logging.LoggerAdapter(logger, extra)
 
         #
         # Set up log level
@@ -218,9 +218,7 @@ class Element:
         numeric_level = getattr(logging, loglevel.upper(), None)
         if not isinstance(numeric_level, int):
             loglevel = LOG_DEFAULT_LEVEL
-        logger.setLevel(loglevel)
-
-        self.logger = logger
+        self.logger.setLevel(loglevel)
 
         # For now, only enable metrics if turned on in an environment flag
         if os.getenv("ATOM_USE_METRICS", "FALSE") == "TRUE":
@@ -389,7 +387,6 @@ class Element:
                 self._stream_reference_sha = script_response[0]
 
         self.logger.info("Element initialized.")
-
 
     def __repr__(self):
         return f"{self.__class__.__name__}({self.name})"

--- a/languages/python/atom/element.py
+++ b/languages/python/atom/element.py
@@ -78,8 +78,6 @@ ATOM_METRICS_SOCKET = os.getenv("ATOM_METRICS_SOCKET", DEFAULT_METRICS_SOCKET)
 # Get the log directory and log file size
 ATOM_LOG_DIR = os.getenv("ATOM_LOG_DIR", "")
 ATOM_LOG_FILE_SIZE = int(os.getenv("ATOM_LOG_FILE_SIZE", LOG_DEFAULT_FILE_SIZE))
-# Initialize the logger
-logger = logging.getLogger(__name__)
 
 
 class ElementConnectionTimeoutError(redis.exceptions.TimeoutError):
@@ -197,6 +195,8 @@ class Element:
         #
         # Set up logger
         #
+        # Initialize the logger
+        logger = logging.getLogger(self.__class__.__name__)
         if not logger.handlers:
             try:
                 rfh = logging.handlers.RotatingFileHandler(


### PR DESCRIPTION
When multiple instances of an element utilize the element logger, a new rotating file handler is added to the logger each time. This was causing duplicate log messages to be outputted to the ATOM_LOG_DIR. 