### PR TITLE
Convert syslog loglevel

### DIFF
--- a/languages/python/atom/element.py
+++ b/languages/python/atom/element.py
@@ -63,7 +63,7 @@ from atom.config import (
 )
 from atom.config import MetricsLevel
 from atom.messages import Cmd, Response, StreamHandler, format_redis_py
-from atom.messages import Acknowledge, Entry, ENTRY_RESERVED_KEYS
+from atom.messages import Acknowledge, Entry, ENTRY_RESERVED_KEYS, LOG_LEVEL_CONVERSION
 import atom.serialization as ser
 
 # Need to figure out how we're connecting to the Nucleus
@@ -2217,7 +2217,10 @@ class Element:
             redis (bool, optional): Default true, whether to log to
                 redis or not
         """
-
+        # Convert syslog level to python log level 
+        converted_level = LOG_LEVEL_CONVERSION.get(level, 0)
+        
+        # Ensure we got a valid python log level 
         numeric_level = getattr(logging, level.name.upper(), None)
         if not isinstance(numeric_level, int):
             numeric_level = getattr(logging, LOG_DEFAULT_LEVEL)

--- a/languages/python/atom/element.py
+++ b/languages/python/atom/element.py
@@ -196,20 +196,25 @@ class Element:
         # Set up logger
         #
         logger = logging.getLogger(self.name)
-        try:
-            rfh = logging.handlers.RotatingFileHandler(
-                f"{ATOM_LOG_DIR}{self.name}.log", maxBytes=ATOM_LOG_FILE_SIZE
-            )
-        except FileNotFoundError as e:
-            raise AtomError(f"Invalid element name for logger: {e}")
+        # If the logger already exists, use it
+        if logger.handlers: 
+            self.logger = logger
+        # Otherwise, create it
+        else: 
+            try:
+                rfh = logging.handlers.RotatingFileHandler(
+                    f"{ATOM_LOG_DIR}{self.name}.log", maxBytes=ATOM_LOG_FILE_SIZE
+                )
+            except FileNotFoundError as e:
+                raise AtomError(f"Invalid element name for logger: {e}")
 
-        extra = {"element_name": self.name}
-        formatter = logging.Formatter(
-            "%(asctime)s element:%(element_name)s [%(levelname)s] %(message)s"
-        )
-        rfh.setFormatter(formatter)
-        logger.addHandler(rfh)
-        self.logger = logging.LoggerAdapter(logger, extra)
+            extra = {"element_name": self.name}
+            formatter = logging.Formatter(
+                "%(asctime)s element:%(element_name)s [%(levelname)s] %(message)s"
+            )
+            rfh.setFormatter(formatter)
+            logger.addHandler(rfh)
+            self.logger = logging.LoggerAdapter(logger, extra)
 
         #
         # Set up log level
@@ -2219,7 +2224,7 @@ class Element:
         """
         # Convert syslog level to python log level 
         converted_level = LOG_LEVEL_CONVERSION.get(level, 0)
-        
+
         # Ensure we got a valid python log level 
         numeric_level = getattr(logging, level.name.upper(), None)
         if not isinstance(numeric_level, int):

--- a/languages/python/atom/element.py
+++ b/languages/python/atom/element.py
@@ -2225,6 +2225,7 @@ class Element:
             redis (bool, optional): Default true, whether to log to
                 redis or not
         """
+
         default_level = getattr(logging, LOG_DEFAULT_LEVEL)
         # Convert syslog log level to python log level
         converted_level = LOG_LEVEL_CONVERSION.get(level, default_level)

--- a/languages/python/atom/element.py
+++ b/languages/python/atom/element.py
@@ -197,10 +197,10 @@ class Element:
         #
         logger = logging.getLogger(self.name)
         # If the logger already exists, use it
-        if logger.handlers: 
+        if logger.handlers:
             self.logger = logger
         # Otherwise, create it
-        else: 
+        else:
             try:
                 rfh = logging.handlers.RotatingFileHandler(
                     f"{ATOM_LOG_DIR}{self.name}.log", maxBytes=ATOM_LOG_FILE_SIZE
@@ -2222,10 +2222,10 @@ class Element:
             redis (bool, optional): Default true, whether to log to
                 redis or not
         """
-        # Convert syslog level to python log level 
+        # Convert syslog level to python log level
         converted_level = LOG_LEVEL_CONVERSION.get(level, 0)
 
-        # Ensure we got a valid python log level 
+        # Ensure we got a valid python log level
         numeric_level = getattr(logging, level.name.upper(), None)
         if not isinstance(numeric_level, int):
             numeric_level = getattr(logging, LOG_DEFAULT_LEVEL)

--- a/languages/python/atom/messages.py
+++ b/languages/python/atom/messages.py
@@ -180,3 +180,12 @@ class LogLevel(Enum):
     NOTICE = 5
     INFO = 6
     DEBUG = 7
+
+# Convert syslog log levels to python log level
+LOG_LEVEL_CONVERSION = {
+    2: 50,
+    3: 40,
+    4: 30,
+    6: 20,
+    7: 10
+}

--- a/languages/python/atom/messages.py
+++ b/languages/python/atom/messages.py
@@ -181,11 +181,6 @@ class LogLevel(Enum):
     INFO = 6
     DEBUG = 7
 
+
 # Convert syslog log levels to python log level
-LOG_LEVEL_CONVERSION = {
-    2: 50,
-    3: 40,
-    4: 30,
-    6: 20,
-    7: 10
-}
+LOG_LEVEL_CONVERSION = {2: 50, 3: 40, 4: 30, 6: 20, 7: 10}

--- a/languages/python/atom/messages.py
+++ b/languages/python/atom/messages.py
@@ -1,4 +1,5 @@
 from enum import Enum
+import logging
 
 import atom.serialization as ser
 
@@ -184,14 +185,9 @@ class LogLevel(Enum):
 
 # Convert syslog log levels to python log level
 LOG_LEVEL_CONVERSION = {
-    # Critical
-    2: 50,
-    # Error
-    3: 40,
-    # Warning
-    4: 30,
-    # Info
-    6: 20,
-    # Debug
-    7: 10,
+    LogLevel.CRIT: logging.CRITICAL,
+    LogLevel.ERR: logging.ERROR,
+    LogLevel.WARNING: logging.WARNING,
+    LogLevel.INFO: logging.INFO,
+    LogLevel.DEBUG: logging.DEBUG,
 }

--- a/languages/python/atom/messages.py
+++ b/languages/python/atom/messages.py
@@ -183,4 +183,15 @@ class LogLevel(Enum):
 
 
 # Convert syslog log levels to python log level
-LOG_LEVEL_CONVERSION = {2: 50, 3: 40, 4: 30, 6: 20, 7: 10}
+LOG_LEVEL_CONVERSION = {
+    # Critical
+    2: 50,
+    # Error
+    3: 40,
+    # Warning
+    4: 30,
+    # Info
+    6: 20,
+    # Debug
+    7: 10,
+}


### PR DESCRIPTION
- Convert syslog log level to python log level to support the deprecated element.log() method
- Retain loggers by element name to avoid duplicating across multiple instances of an element 