### PR TITLE
atom orb: add build labels

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -125,6 +125,29 @@ circleci orb publish promote elementaryrobotics/atom@dev:some-tag patch
 
 ### Release Notes
 
+#### [v0.1.11](https://circleci.com/orbs/registry/orb/elementaryrobotics/atom?version=0.1.11)
+
+##### New Features
+
+Adds in labels to all Docker images built. The following labels are added to all docker images:
+
+| Label | Description |
+|-------|-------------|
+| `com.elementaryrobotics.branch` | Git branch the image was built off of|
+| `com.elementaryrobotics.build_num` | CircleCI build number the image was built off of |
+| `com.elementaryrobotics.build_url` | URL to the CircleCI build for the image|
+| `com.elementaryrobotics.commit` | SHA1 of git commit for the image |
+| `com.elementaryrobotics.repo` | Git reposity for the image |
+| `com.elementaryrobotics.tag` | Typically blank, will be non-blank if this is a build run due to a new tag. |
+| `com.elementaryrobotics.describe` | Output of `git describe --tags`  for the build |
+
+Labels can be seen using `docker image inspect` on any image.
+
+##### Upgrade Steps
+
+- Upgrade to new orb only, no other action required
+
+
 #### [v0.1.10](https://circleci.com/orbs/registry/orb/elementaryrobotics/atom?version=0.1.10)
 
 ##### New Features

--- a/.circleci/atom.yml
+++ b/.circleci/atom.yml
@@ -437,6 +437,13 @@ commands:
           command: >-
             << parameters.build_invocation >>
             << parameters.build_additional_command >>
+            --label "com.elementaryrobotics.tag=${CIRCLE_TAG}"
+            --label "com.elementaryrobotics.branch=${CIRCLE_BRANCH}"
+            --label "com.elementaryrobotics.repo=${CIRCLE_PROJECT_REPONAME}"
+            --label "com.elementaryrobotics.commit=${CIRCLE_SHA1}"
+            --label "com.elementaryrobotics.describe=$(git describe --tags)"
+            --label "com.elementaryrobotics.build_num=${CIRCLE_BUILD_NUM}"
+            --label "com.elementaryrobotics.build_url=${CIRCLE_BUILD_URL}"
             -t << parameters.image_name >>:<< parameters.image_tag >>-<< parameters.variant >>-<< parameters.platform >>
             << parameters.build_command >>
             << parameters.build_context >>


### PR DESCRIPTION
Adds in automatic build labeling to all Atom orb users (on orb upgrade). See README for info