### PR TITLE
Add type checking to formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,32 @@ docker run -e BLACK_EXCLUDE="" -e FLAKE8_EXCLUDE="" --mount src=$(pwd),target=/c
 
 After running this, check the return code with `echo $?` to see if the checks passed. If the return code is 0, then the checks passed, if nonzero then there were formatting inconsistencies. The logs will also be indicative.
 
+To check your code using a type checker:
+```
+docker run -e BLACK_EXCLUDE="" -e FLAKE8_EXCLUDE="" -e CHECK_PYRIGHT="y" \
+  --mount src=$(pwd),target=/code,type=bind \
+  --mount src=<virtualenv_dir>,target=/.venvs,type=bind,readonly \
+  elementary/formatter .
+```
+
+This runs the pyright type checker. A file named `pyrightconfig.json` must exist
+in the current directory (example below). Replace `<virtualenv_dir>` in the
+docker command with the path to a directory containing one or more
+subdirectories, each of which contains a virtual environment. This enables
+pyright to discover packages while type checking. Check the [pyright
+documentation](https://github.com/microsoft/pyright/blob/master/docs/configuration.md)
+for configuration details.
+```json
+{
+    "exclude": [
+        "**/__pycache__",
+    ],
+    "venvPath": "/.venvs",
+    "pythonVersion": "3.7",
+    "pythonPlatform": "Linux"
+}
+```
+
 To reformat your code:
 ```
 docker run -e DO_FORMAT=y -e BLACK_EXCLUDE="" -e FLAKE8_EXCLUDE="" --mount src=$(pwd),target=/code,type=bind elementaryrobotics/formatter
@@ -145,6 +171,8 @@ The formatter exposes the following command-line options which are used in the [
 | `DO_FORMAT` | "" | If non-empty, i.e. not "", run the auto-formatter before running the formatting check. Default is to not run the auto-formatter |
 | `FORMAT_BLACK` | "y" | Use Black as the auto-formatter of choice. This is default, but we may add other auto-formatters in the future. Set to empty to not use black. |
 | `DO_CHECK` | "y" | If non-empty, i.e. not "", run the formatting/linting check automatically. This is the default. |
+| `CHECK_ISORT` | "y" | If non-empty, i.e. not "", run the isort linting check automatically. This is the default. Checks for incorrectly sorted and/or formatted imports. |
+| `CHECK_PYRIGHT` | "" | If non-empty, i.e. not "", run the pyright type checker automatically. Off by default. |
 | `DO_HANG` | "" | If non-empty, instead of returning when finished, hang the container. This is nice if you want to then shell in to the container and play around with the formatter, but otherwise not that useful |
 
 

--- a/languages/python/atom/pyrightconfig.json
+++ b/languages/python/atom/pyrightconfig.json
@@ -1,0 +1,9 @@
+{
+    "exclude": [
+        "**/__pycache__",
+    ],
+    "venvPath": "/.venvs",
+    "reportMissingImports": true,
+    "pythonVersion": "3.7",
+    "pythonPlatform": "Linux"
+}

--- a/utilities/formatting/Dockerfile
+++ b/utilities/formatting/Dockerfile
@@ -1,11 +1,12 @@
-FROM alpine/flake8:3.7.0
+FROM alpine/flake8:3.8.4
 
 ADD ./requirements.txt .
 
 # Need to install build tools and auto-formatters
-RUN apk add git openssh build-base && \
-    pip3 install --upgrade pip && \
-    pip3 install -r requirements.txt
+RUN apk add git openssh build-base npm \
+    && pip3 install --upgrade pip \
+    && pip3 install -r requirements.txt \
+    && npm install -g pyright
 
 # Add in the .flake8 spec
 ADD ./.flake8 /usr/local/lib/.flake8
@@ -31,6 +32,8 @@ ENV FORMAT_BLACK="y"
 # Do check automatically. Set to something empty
 #   to turn off checking
 ENV DO_CHECK="y"
+ENV CHECK_ISORT="y"
+ENV CHECK_PYRIGHT=""
 
 # Don't hang automatically. This is useful for dev
 #   purposes but shouldn't be turned on in prod

--- a/utilities/formatting/run.sh
+++ b/utilities/formatting/run.sh
@@ -25,12 +25,19 @@ fi
 # If we should check
 if [[ ! -z ${DO_CHECK} ]]; then
 
-    # Do an isort first
-    cd $CODE_DIR && isort --profile black --check ${ISORT_EXCLUDE} . || exit 1
+    # If we're using isort, do an isort first
+    if [[ ! -z ${CHECK_ISORT} ]]; then
+        cd $CODE_DIR && isort --profile black --check ${ISORT_EXCLUDE} . || exit 1
+    fi
 
     # If we're using black
     if [[ ! -z ${FORMAT_BLACK} ]]; then
         /usr/local/bin/black --check --exclude="${BLACK_EXCLUDE}" ${CODE_DIR} || exit 1
+    fi
+
+    # If we're using pyright
+    if [[ ! -z ${CHECK_PYRIGHT} ]]; then
+        cd $CODE_DIR && /usr/bin/pyright -p ./pyrightconfig.json ${CODE_DIR} || exit 1
     fi
 
     # Always run flake8


### PR DESCRIPTION
- Add pyright type checker to formatter
- Update instructions in README for running formatter with type checking
- Added environment variable `CHECK_ISORT` (default on) while linting
- Update formatter image to latest and greatest in order to install pyright
  - Pyright is installed using npm. `alpine/flake8:3.7.0` would install npm but would error upon `npm install -g pyright` due to a bug. Bugfixes that unblock pyright installation are available in `alpine/flake8:3.8.4`. 

Closes #410 