### PR TITLE
atom: build improvements

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -125,6 +125,17 @@ circleci orb publish promote elementaryrobotics/atom@dev:some-tag patch
 
 ### Release Notes
 
+#### [v0.1.12](https://circleci.com/orbs/registry/orb/elementaryrobotics/atom?version=0.1.12)
+
+##### New Features
+
+- Upgrades `build-ubuntu` machine to `ubuntu-2004:202101-01`. This brings in Docker v20.10.2 and Docker Compose v1.28.2. The goal is to mitigate a bug in previous versions which caused files/layers to be missing from the final step in a Dockerfile.
+- Minor internal build stability improvement. Might reduce job failures due to `buildx` not running properly.
+
+##### Upgrade Steps
+
+- No action needed.
+
 #### [v0.1.11](https://circleci.com/orbs/registry/orb/elementaryrobotics/atom?version=0.1.11)
 
 ##### New Features
@@ -146,7 +157,6 @@ Labels can be seen using `docker image inspect` on any image.
 ##### Upgrade Steps
 
 - Upgrade to new orb only, no other action required
-
 
 #### [v0.1.10](https://circleci.com/orbs/registry/orb/elementaryrobotics/atom?version=0.1.10)
 

--- a/.circleci/atom.yml
+++ b/.circleci/atom.yml
@@ -187,24 +187,17 @@ aliases:
 #
 executors:
 
-  # Machine used to build docker containers using the
-  # CircleCI classic image
-  build-classic:
-    machine:
-      enabled: true
-      image: circleci/classic:201808-01
-    environment:
-      DOCKER_CLI_EXPERIMENTAL: enabled
-    resource_class: medium
-
-  # Ubuntu 16.04 machine used to build some images
-  # comes with Docker 19.03.8 and docker-compose 1.25.5
+  # Ubuntu Machine used to build some images
+  # Docker v20.10.2, Docker Compose v1.28.2,
   # This is useful since `buildx`, which is required in order
-  # to cross-compile images, comes standard in Docker 19.03
+  # to cross-compile images, comes standard in Docker 19.03. There are
+  # some buildx bugs that caused layers/files to be dropped that might be
+  # resolved in 20.10.0, so we should ensure we're running a version
+  # newer than this.
   build-ubuntu:
     machine:
       enabled: true
-      image: ubuntu-1604:202004-01
+      image: ubuntu-2004:202101-01
     environment:
       DOCKER_CLI_EXPERIMENTAL: enabled
     resource_class: medium
@@ -469,6 +462,11 @@ commands:
       << : *build_buildx_additional_args
     steps:
       - enable_buildx
+
+      # Starts up the buildx engine and prints out some info about it
+      - run:
+          name: Start up buildx and inspect
+          command: docker buildx inspect --bootstrap
 
       # Run the actual build. Due to a bug in the buildx cache pushing
       # in that it's failing intermittently we don't set the

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,7 +275,7 @@ aliases:
 version: 2.1
 
 orbs:
-  atom:  elementaryrobotics/atom@0.1.9
+  atom:  elementaryrobotics/atom@dev:upgrade-docker
 
 commands:
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,7 +275,7 @@ aliases:
 version: 2.1
 
 orbs:
-  atom:  elementaryrobotics/atom@dev:upgrade-docker
+  atom:  elementaryrobotics/atom@0.1.12
 
 commands:
 


### PR DESCRIPTION
- Upgrade docker to 20.10.2 to fix missing file bug
- launch/inspect the build engine before running build to
fix intermittent failure bug.