### PR TITLE
Orb Support for ARM executors

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -125,6 +125,65 @@ circleci orb publish promote elementaryrobotics/atom@dev:some-tag patch
 
 ### Release Notes
 
+#### [v0.2.0](https://circleci.com/orbs/registry/orb/elementaryrobotics/atom?version=0.2.0)
+
+##### New Features
+
+- Adds in the ability to build ARM with CircleCI's new ARM linux executors. This speeds up ARM builds by roughly 10x as they're no longer done in QEMU/simulation.
+
+##### Upgrade Steps
+
+In previous versions, to build ARM, one would set up a job in a .circleci file similar to:
+
+```
+  - atom/build_buildx:
+      name: "build-<< matrix.platform >>-<< matrix.stage >>"
+      matrix:
+        parameters:
+          platform: [ amd64, aarch64 ]
+      image_name: << pipeline.parameters.dockerhub_repo >>
+      image_tag: build-<< pipeline.number >>-<< matrix.stage >>
+      cache_repo: << pipeline.parameters.dockerhub_repo >>
+      cache_tag: build-cache
+      build_args: --build-arg ATOM_IMAGE=<< pipeline.parameters.atom_repo >>:<< pipeline.parameters.atom_version >>-<< pipeline.parameters.atom_variant >>-<< matrix.platform >>
+      filters:
+        tags:
+          only: /.*/
+```
+
+Now, we need to change the `matrix` section to include information about the `executor`. In order
+to minimize disruption, we require both the `executor` and `platform` information, even
+though they're technically redundant. This can be improved in a future release. We need to then
+have our build jobs look like
+
+```
+  - atom/build_buildx:
+      name: "build-<< matrix.platform >>-<< matrix.stage >>"
+      matrix:
+        parameters:
+          platform: [ amd64, aarch64 ]
+          executor: [ atom/build-ubuntu, atom/build-ubuntu-arm]
+          exclude:
+            - platform: amd64
+              executor: atom/build-ubuntu-arm
+            - platform: aarch64
+              executor: atom/build-ubuntu
+      image_name: << pipeline.parameters.dockerhub_repo >>
+      image_tag: build-<< pipeline.number >>-<< matrix.stage >>
+      cache_repo: << pipeline.parameters.dockerhub_repo >>
+      cache_tag: build-cache
+      build_args: --build-arg ATOM_IMAGE=<< pipeline.parameters.atom_repo >>:<< pipeline.parameters.atom_version >>-<< pipeline.parameters.atom_variant >>-<< matrix.platform >>
+      filters:
+        tags:
+          only: /.*/
+```
+
+The exclude section is necessary so that we get exactly two build jobs, one for
+`amd64` with `atom/build-ubuntu` and one for `aarch64` with `atom/build-ubuntu-arm`.
+
+This only needs to be done on `build_buildx` jobs, the deploys can all be done on Intel without
+any performance hit and without issue.
+
 #### [v0.1.12](https://circleci.com/orbs/registry/orb/elementaryrobotics/atom?version=0.1.12)
 
 ##### New Features

--- a/.circleci/atom.yml
+++ b/.circleci/atom.yml
@@ -41,6 +41,9 @@ aliases:
       use_git_lfs:
         type: boolean
         default: false
+      executor:
+        type: executor
+        default: build-ubuntu
 
   # Mapping to pass build args through without modification
   - &build_basic_args_mapping
@@ -125,6 +128,9 @@ aliases:
       use_git_lfs:
         type: boolean
         default: false
+      executor:
+        type: executor
+        default: build-ubuntu
 
   - &test_shared_args_mapping
       platform: << parameters.platform >>
@@ -194,6 +200,7 @@ executors:
   # some buildx bugs that caused layers/files to be dropped that might be
   # resolved in 20.10.0, so we should ensure we're running a version
   # newer than this.
+
   build-ubuntu:
     machine:
       enabled: true
@@ -201,6 +208,30 @@ executors:
     environment:
       DOCKER_CLI_EXPERIMENTAL: enabled
     resource_class: medium
+
+  build-ubuntu-large:
+    machine:
+      enabled: true
+      image: ubuntu-2004:202101-01
+    environment:
+      DOCKER_CLI_EXPERIMENTAL: enabled
+    resource_class: large
+
+  build-ubuntu-arm:
+    machine:
+      enabled: true
+      image: ubuntu-2004:202101-01
+    environment:
+      DOCKER_CLI_EXPERIMENTAL: enabled
+    resource_class: arm.medium
+
+  build-ubuntu-arm-large:
+    machine:
+      enabled: true
+      image: ubuntu-2004:202101-01
+    environment:
+      DOCKER_CLI_EXPERIMENTAL: enabled
+    resource_class: arm.large
 
   # Docker-in-docker. Need to call setup_remote_docker
   # before using. Useful when you don't need a bunch of
@@ -574,68 +605,27 @@ jobs:
           command: CODE_DIR=/root/project FLAKE8_EXCLUDE=<< parameters.flake8_exclude>> BLACK_EXCLUDE=<< parameters.black_exclude >> FORMAT_BLACK=<< parameters.use_black >> /usr/local/bin/run.sh
 
   build:
-    executor: build-ubuntu
     parameters:
       << : *build_basic_args
-    steps:
-      - build_shared:
-          << : *build_basic_args_mapping
-
-  build_large:
-    executor: build-ubuntu
-    resource_class: large
-    parameters:
-      << : *build_basic_args
-    steps:
-      - build_shared:
-          << : *build_basic_args_mapping
-
-  build_xlarge:
-    executor: build-ubuntu
-    resource_class: xlarge
-    parameters:
-      << : *build_basic_args
+    executor: << parameters.executor >>
     steps:
       - build_shared:
           << : *build_basic_args_mapping
 
   build_buildx:
-    executor: build-ubuntu
     parameters:
       << : *build_basic_args
       << : *build_buildx_additional_args
+    executor: << parameters.executor >>
     steps:
       - build_buildx_shared:
           << : *build_basic_args_mapping
           << : *build_buildx_additional_args_mapping
 
-  build_buildx_large:
-    executor: build-ubuntu
-    resource_class: large
-    parameters:
-      << : *build_basic_args
-      << : *build_buildx_additional_args
-    steps:
-      - build_buildx_shared:
-          << : *build_basic_args_mapping
-          << : *build_buildx_additional_args_mapping
-
-  build_buildx_xlarge:
-    executor: build-ubuntu
-    resource_class: xlarge
-    parameters:
-      << : *build_basic_args
-      << : *build_buildx_additional_args
-    steps:
-      - build_buildx_shared:
-          << : *build_basic_args_mapping
-          << : *build_buildx_additional_args_mapping
-
-  # Run Tests
   test:
-    executor: build-ubuntu
     parameters:
       << : *test_shared_args
+    executor: << parameters.executor >>
     steps:
       - when:
           condition: << parameters.use_git_lfs >>

--- a/.circleci/atom.yml
+++ b/.circleci/atom.yml
@@ -430,14 +430,15 @@ commands:
 
   # Prepare the machine for buildx based builds
   enable_buildx:
-    description: "Prepare the CircleCI machine for cross-compiling ARM images"
+    description: "Prepare the CircleCI machine for using buildx"
     steps:
-      - run:
-          name: Setup binfmt_misc
-          command: cat /proc/sys/fs/binfmt_misc/qemu-aarch64 | grep enabled || docker run --rm --privileged docker/binfmt:66f9012c56a8316f9244ffd7622d7c21c1f6f28d
       - run:
           name: Switch to the multi-arch builder
           command: docker buildx ls | grep "build-buildx" || docker buildx create --use --name build-buildx
+      - run:
+          name: Start up buildx and inspect
+          command: docker buildx inspect --bootstrap
+
 
   # Run a Dockerfile build command
   run_dockerfile_build:
@@ -493,11 +494,6 @@ commands:
       << : *build_buildx_additional_args
     steps:
       - enable_buildx
-
-      # Starts up the buildx engine and prints out some info about it
-      - run:
-          name: Start up buildx and inspect
-          command: docker buildx inspect --bootstrap
 
       # Run the actual build. Due to a bug in the buildx cache pushing
       # in that it's failing intermittently we don't set the

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,9 @@ aliases:
       test_valgrind:
         type: boolean
         default: true
+      executor:
+        type: executor
+        default: atom/build-ubuntu
 
   # Typical mapping of params for building atom.
   #   NOTE: you will always need to specify:
@@ -275,7 +278,7 @@ aliases:
 version: 2.1
 
 orbs:
-  atom:  elementaryrobotics/atom@0.1.12
+  atom:  elementaryrobotics/atom@dev:arm
 
 commands:
 
@@ -536,7 +539,7 @@ jobs:
       production_image:
         type: string
         default: debian:buster-slim
-    executor: atom/build-ubuntu
+    executor: << parameters.executor >>
     steps:
       - build_shared_init
       - build_atom_with_nucleus_variant:
@@ -550,7 +553,7 @@ jobs:
       production_image:
         type: string
         default: debian:buster-slim
-    executor: atom/build-ubuntu
+    executor: << parameters.executor >>
     steps:
       - build_shared_init
       - build_atom_variant:
@@ -562,7 +565,7 @@ jobs:
   build-base:
     parameters:
       << : *build_atom_variant_shared_params
-    executor: atom/build-ubuntu
+    executor: << parameters.executor >>
     resource_class: medium
     steps:
       - build_shared_init
@@ -578,7 +581,7 @@ jobs:
         type: string
       previous:
         type: string
-    executor: atom/build-ubuntu
+    executor: << parameters.executor >>
     resource_class: large
     steps:
       - build_shared_init
@@ -654,7 +657,7 @@ workflows:
       #     - opengl-cuda-vnc
       #   AARCH64
       #     - stock
-      #
+      #     - opencv
 
       #
       # AMD64 / Intel
@@ -777,6 +780,7 @@ workflows:
             parameters:
               variant: [ stock ]
               platform: [ aarch64 ]
+              executor: [ atom/build-ubuntu-arm ]
           base_tag: *base_build_atom_stock_aarch64_tag
           production_image: debian:buster-slim
           test_valgrind: false
@@ -795,6 +799,7 @@ workflows:
             parameters:
               variant: [ opencv ]
               platform: [ aarch64 ]
+              executor: [ atom/build-ubuntu-arm ]
           base_tag: *base_build_atom_opencv_aarch64_tag
           production_image: debian:buster-slim
           test_valgrind: false
@@ -961,20 +966,21 @@ workflows:
               only: /.*/
 
       # Build for ARM
-      # - atom/build_buildx:
-      #     name: "build-metrics-<< matrix.platform >>"
-      #     matrix:
-      #       parameters:
-      #         platform: [ aarch64 ]
-      #     working_directory: metrics
-      #     image_name: << pipeline.parameters.dockerhub_org >>/<< pipeline.parameters.metrics_repo_name >>
-      #     image_tag: build-<< pipeline.number >>
-      #     cache_repo: << pipeline.parameters.dockerhub_org >>/<< pipeline.parameters.metrics_repo_name >>
-      #     cache_tag: cache
-      #     build_args: "--build-arg NODE_ARCH=arm64"
-      #     filters:
-      #       tags:
-      #         only: /.*/
+      - atom/build_buildx:
+          name: "build-metrics-<< matrix.platform >>"
+          matrix:
+            parameters:
+              platform: [ aarch64 ]
+              executor: [ atom/build-ubuntu-arm ]
+          working_directory: metrics
+          image_name: << pipeline.parameters.dockerhub_org >>/<< pipeline.parameters.metrics_repo_name >>
+          image_tag: build-<< pipeline.number >>
+          cache_repo: << pipeline.parameters.dockerhub_org >>/<< pipeline.parameters.metrics_repo_name >>
+          cache_tag: cache
+          build_args: "--build-arg NODE_ARCH=arm64"
+          filters:
+            tags:
+              only: /.*/
 
       # Deploy development
       - atom/deploy:
@@ -983,7 +989,7 @@ workflows:
           target_tag: development-<< pipeline.number >>
           matrix:
             parameters:
-              platform: [ amd64 ]
+              platform: [ amd64, aarch64 ]
           requires:
             - "build-metrics-<< matrix.platform >>"
           filters:
@@ -998,7 +1004,7 @@ workflows:
           target_tag: latest-<< pipeline.number >>
           matrix:
             parameters:
-              platform: [ amd64 ]
+              platform: [ amd64, aarch64 ]
           requires:
             - "build-metrics-<< matrix.platform >>"
           filters:
@@ -1013,7 +1019,7 @@ workflows:
           target_tag: ""
           matrix:
             parameters:
-              platform: [ amd64 ]
+              platform: [ amd64, aarch64 ]
           requires:
             - "build-metrics-<< matrix.platform >>"
           filters:
@@ -1028,7 +1034,7 @@ workflows:
           target_tag: ${CIRCLE_TAG}
           matrix:
             parameters:
-              platform: [ amd64 ]
+              platform: [ amd64, aarch64 ]
           requires:
             - "build-metrics-<< matrix.platform >>"
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,7 +278,7 @@ aliases:
 version: 2.1
 
 orbs:
-  atom:  elementaryrobotics/atom@dev:arm
+  atom:  elementaryrobotics/atom@0.2.0
 
 commands:
 
@@ -783,7 +783,6 @@ workflows:
               executor: [ atom/build-ubuntu-arm ]
           base_tag: *base_build_atom_stock_aarch64_tag
           production_image: debian:buster-slim
-          build_args: --no-cache
           test_valgrind: false
           filters:
             tags:
@@ -803,7 +802,6 @@ workflows:
               executor: [ atom/build-ubuntu-arm ]
           base_tag: *base_build_atom_opencv_aarch64_tag
           production_image: debian:buster-slim
-          build_args: --no-cache
           test_valgrind: false
           requires:
             - build-atom-stock-aarch64
@@ -979,7 +977,7 @@ workflows:
       #     image_tag: build-<< pipeline.number >>
       #     cache_repo: << pipeline.parameters.dockerhub_org >>/<< pipeline.parameters.metrics_repo_name >>
       #     cache_tag: cache
-      #     build_args: "--build-arg NODE_ARCH=arm64 --no-cache"
+      #     build_args: "--build-arg NODE_ARCH=arm64"
       #     filters:
       #       tags:
       #         only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -783,6 +783,7 @@ workflows:
               executor: [ atom/build-ubuntu-arm ]
           base_tag: *base_build_atom_stock_aarch64_tag
           production_image: debian:buster-slim
+          build_args: --no-cache
           test_valgrind: false
           filters:
             tags:
@@ -802,6 +803,7 @@ workflows:
               executor: [ atom/build-ubuntu-arm ]
           base_tag: *base_build_atom_opencv_aarch64_tag
           production_image: debian:buster-slim
+          build_args: --no-cache
           test_valgrind: false
           requires:
             - build-atom-stock-aarch64
@@ -966,21 +968,21 @@ workflows:
               only: /.*/
 
       # Build for ARM
-      - atom/build_buildx:
-          name: "build-metrics-<< matrix.platform >>"
-          matrix:
-            parameters:
-              platform: [ aarch64 ]
-              executor: [ atom/build-ubuntu-arm ]
-          working_directory: metrics
-          image_name: << pipeline.parameters.dockerhub_org >>/<< pipeline.parameters.metrics_repo_name >>
-          image_tag: build-<< pipeline.number >>
-          cache_repo: << pipeline.parameters.dockerhub_org >>/<< pipeline.parameters.metrics_repo_name >>
-          cache_tag: cache
-          build_args: "--build-arg NODE_ARCH=arm64"
-          filters:
-            tags:
-              only: /.*/
+      # - atom/build_buildx:
+      #     name: "build-metrics-<< matrix.platform >>"
+      #     matrix:
+      #       parameters:
+      #         platform: [ aarch64 ]
+      #         executor: [ atom/build-ubuntu-arm ]
+      #     working_directory: metrics
+      #     image_name: << pipeline.parameters.dockerhub_org >>/<< pipeline.parameters.metrics_repo_name >>
+      #     image_tag: build-<< pipeline.number >>
+      #     cache_repo: << pipeline.parameters.dockerhub_org >>/<< pipeline.parameters.metrics_repo_name >>
+      #     cache_tag: cache
+      #     build_args: "--build-arg NODE_ARCH=arm64 --no-cache"
+      #     filters:
+      #       tags:
+      #         only: /.*/
 
       # Deploy development
       - atom/deploy:
@@ -989,7 +991,7 @@ workflows:
           target_tag: development-<< pipeline.number >>
           matrix:
             parameters:
-              platform: [ amd64, aarch64 ]
+              platform: [ amd64 ]
           requires:
             - "build-metrics-<< matrix.platform >>"
           filters:
@@ -1004,7 +1006,7 @@ workflows:
           target_tag: latest-<< pipeline.number >>
           matrix:
             parameters:
-              platform: [ amd64, aarch64 ]
+              platform: [ amd64 ]
           requires:
             - "build-metrics-<< matrix.platform >>"
           filters:
@@ -1019,7 +1021,7 @@ workflows:
           target_tag: ""
           matrix:
             parameters:
-              platform: [ amd64, aarch64 ]
+              platform: [ amd64 ]
           requires:
             - "build-metrics-<< matrix.platform >>"
           filters:
@@ -1034,7 +1036,7 @@ workflows:
           target_tag: ${CIRCLE_TAG}
           matrix:
             parameters:
-              platform: [ amd64, aarch64 ]
+              platform: [ amd64 ]
           requires:
             - "build-metrics-<< matrix.platform >>"
           filters:


### PR DESCRIPTION
Atom ARM builds (for shipped atom containers, not base builds at the moment) now build using CircleCI's new ARM resources. This drastically improves build time and reduces cost by no longer needing to run everything for ARM in simulation through QEMU in the `buildx` docker engine.

This does make a slight breaking change to the orb, so the orb is now bumped to `0.2.0`. Upgrade instructions for users are fairly straightforward, and the build config required for anyone using the orb is slightly wordier/more verbose. See circleci README in this PR for more info.

Rebasing #404 atop this should fix the unit tests failing at the moment due to being CPU constrained on ARM builds.