### PR TITLE
430/tighten up types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,7 +295,7 @@ commands:
           command: docker exec -it -w /atom/languages/python/tests << parameters.container >> python -V 2>&1 | grep "3.7"
       - run:
           name: Python type check
-          command: docker exec -it << parameters.container >> pyright --lib /atom/languages/python/atom
+          command: docker exec -it << parameters.container >> pyright -p pyrightconfig-ci.json /atom/languages/python/atom
       - run:
           name: Python tests
           command: docker exec -it -w /atom/languages/python/tests << parameters.container >> pytest -vv --durations=0 --capture=tee-sys

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,7 +295,7 @@ commands:
           command: docker exec -it -w /atom/languages/python/tests << parameters.container >> python -V 2>&1 | grep "3.7"
       - run:
           name: Python type check
-          command: docker exec -it << parameters.container >> pyright -p pyrightconfig-ci.json /atom/languages/python/atom
+          command: docker exec -it << parameters.container >> bash -c "cd /atom/languages/python && pyright -p pyrightconfig-ci.json atom"
       - run:
           name: Python tests
           command: docker exec -it -w /atom/languages/python/tests << parameters.container >> pytest -vv --durations=0 --capture=tee-sys

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ build/
 dist/
 *.egg-info/
 *.rdb
+
+poetry.lock
+.python-version
+pyrightconfig.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -221,9 +221,12 @@ RUN pip3 install --no-cache-dir -r requirements-test.txt
 RUN apt install -y curl
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt install -y nodejs && npm install -g pyright
+# Copy in pyright config for running pyright on atom source code
+ADD ./languages/python/pyrightconfig-ci.json /atom/languages/python/pyrightconfig-ci.json
 
 
 # Copy source code
 COPY ./languages/c/ /atom/languages/c
 COPY ./languages/cpp/ /atom/languages/cpp
 COPY ./languages/python/tests /atom/languages/python/tests
+COPY ./languages/python/atom /atom/languages/python/atom

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ to be merged into `latest` without passing.
 
 #### Python
 
+To set up type checking and code completion in your text editor, [see the wiki](https://github.com/elementary-robotics/wiki/wiki/Python-Code-Completion-and-Type-Checking-in-Text-Editors).
+
 ##### Formatting for Atom
 
 Atom utilizes the following formatting guidelines:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -9,7 +9,7 @@ services:
       dockerfile: Dockerfile
       target: nucleus
       args:
-        BASE_IMAGE: elementaryrobotics/atom:v2.7.0-base-stock-amd64
+        BASE_IMAGE: elementaryrobotics/atom:v2.7.1-base-stock-amd64
     volumes:
       - type: volume
         source: shared
@@ -60,7 +60,7 @@ services:
       dockerfile: Dockerfile
       target: test
       args:
-        BASE_IMAGE: elementaryrobotics/atom:v2.7.0-base-opencv-amd64
+        BASE_IMAGE: elementaryrobotics/atom:v2.7.1-base-opencv-amd64
     volumes:
       - type: volume
         source: shared

--- a/languages/python/README.md
+++ b/languages/python/README.md
@@ -3,15 +3,29 @@
 - Redis
 
 ### Setup
+
 ```
 pip install -r requirements.txt
 ```
+
 ```
 python setup_local.py install
 ```
 
+#### `pyright` for type checking and code completion in your text editor
+
+[See wiki](https://github.com/elementary-robotics/wiki/wiki/Python-Code-Completion-and-Type-Checking-in-Text-Editors)
+
+Note: `pyright` can't resolve `atom` imports like `from atom.config import ...`, unless it's run in the `languages/python` directory (this one).
+
+Also, `pyright` can has trouble with these imports if the `pyrightconfig.json` file isn't in the same directory from which pyright is run. We could either change the `atom` imports to be relative imports, or we can just run `pyright` from this directory.
+
+If you want type checking in your text editor, you probably want this directory at the root of your "project".
+
 ### Testing
+
 Make sure the Redis server is running, then run pytest
+
 ```
 pytest
 ```

--- a/languages/python/atom/config.py
+++ b/languages/python/atom/config.py
@@ -115,4 +115,4 @@ class MetricsLevel(Enum):
 LOG_DEFAULT_FILE_SIZE = 2000
 LOG_DEFAULT_LEVEL = "INFO"
 
-VERSION = "2.7.0"
+VERSION = "2.7.1"

--- a/languages/python/pyrightconfig-ci.json
+++ b/languages/python/pyrightconfig-ci.json
@@ -1,0 +1,13 @@
+{
+  "useLibraryCodeForTypes": true,
+  "typeCheckingMode": "basic",
+  "reportOptionalSubscript": "error",
+  "reportOptionalMemberAccess": "error",
+  "reportOptionalCall": "error",
+  "reportOptionalIterable": "error",
+  "reportOptionalContextManager": "error",
+  "reportOptionalOperand": "error",
+  "strictListInference": true,
+  "strictDictionaryInference": true,
+  "reportUnnecessaryCast": "error"
+}

--- a/languages/python/setup.py
+++ b/languages/python/setup.py
@@ -5,7 +5,7 @@ import setuptools
 setuptools.setup(
     name="elementary-atom",
     packages=["atom"],
-    version="2.7.0",
+    version="2.7.1",
     include_package_data=True,
     keywords="elementary robotics atom redis rts",
     url="https://github.com/elementary-robotics/atom",

--- a/languages/python/setup_local.py
+++ b/languages/python/setup_local.py
@@ -4,6 +4,6 @@ import setuptools
 setuptools.setup(
     name="atom",
     packages=["atom"],
-    version="2.7.0",
+    version="2.7.1",
     include_package_data=True,
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[tool.poetry]
+name = "atom"
+version = "0.1.0"
+description = "For installing dev deps on host machine"
+authors = []
+
+[tool.poetry.dependencies]
+python = "^3.7"
+Cython = "0.29.16"
+hiredis = "1.1.0"
+msgpack = "0.6.2"
+numpy = "1.18.3"
+prompt-toolkit = "2.0.7"
+psutil = "5.8.0"
+pyarrow = "0.17.0"
+pyfiglet = "0.7.6"
+pytest = "6.2.2"
+redis = "3.5.3"
+redistimeseries = "1.4.3"
+rmtest = "0.7.0"
+six = "1.15.0"
+wcwidth = "0.2.5"
+typing_extensions = "3.7.4.3"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Closes #430 

- bumps to version `2.7.1` (we can cut tag and publish release on PyPI once we merge this)

**Most importantly, this actually runs type checks on the source code**. We weren't doing this previously, because the `Dockerfile` wasn't copying in `atom` source code to `/atom/languages/python/atom` for the `test` stage. See this build from a few days ago:

https://app.circleci.com/pipelines/github/elementary-robotics/atom/2037/workflows/9ef6bd4c-ef57-422d-9900-9e961e48a3de/jobs/15756

![Screen Shot 2021-03-18 at 8 40 46 AM](https://user-images.githubusercontent.com/1524088/111645438-4ffa2500-87c6-11eb-8586-de6439934e9d.png)

We're running tests on 0 files. `pyright` exits with a successful status code, but it doesn't actually run any tests!

Here's how things look in the new build:

<img width="1142" alt="Screen Shot 2021-03-18 at 9 01 51 AM" src="https://user-images.githubusercontent.com/1524088/111648409-efb8b280-87c8-11eb-8b01-69ece4c6c88b.png">
