### PR TITLE
atom orb: upgade buildkit to v0.8.3

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -125,6 +125,13 @@ circleci orb publish promote elementaryrobotics/atom@dev:some-tag patch
 
 ### Release Notes
 
+#### [v0.3.2](https://circleci.com/orbs/registry/orb/elementaryrobotics/atom?version=0.3.2)
+
+##### New Features
+
+- Upgrades buildkit to v0.8.3 and makes buildkit version independent from CircleCI machine image version.
+- Hopefully fixes missing layer bug with the buildkit upgrade.
+
 #### [v0.3.1](https://circleci.com/orbs/registry/orb/elementaryrobotics/atom?version=0.3.1)
 
 ##### New Features

--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -125,6 +125,32 @@ circleci orb publish promote elementaryrobotics/atom@dev:some-tag patch
 
 ### Release Notes
 
+#### [v0.3.3](https://circleci.com/orbs/registry/orb/elementaryrobotics/atom?version=0.3.3)
+
+##### New Features
+
+- Adds `use_cache` arg to build steps (default true) which indicates whether or not to use the buildkit --cache-from statement when starting a job. It's sometimes useful to turn this off in the presence of build errors due to buildkit caching. Ideally this will never need to be used, but it can help get out of a pinch with a corrupted build.
+- Updates the templates to populate the `use_cache` orb arg with a pipeline parameter so that we can launch jobs from the CLI to do rebuilds with caching off.
+
+Once you've upgraded to this orb/config template, you can launch a job for a full rebuild without caching using the CircleCI API using the steps below:
+
+1. Get a [token](https://circleci.com/docs/2.0/managing-api-tokens/)
+2. Launch job (choose either branch or tag, not both)
+```
+curl -u ${CIRCLECI_TOKEN}: -X POST --header "Content-Type: application/json" -d '{
+  "branch": "<branch_name>",
+  "tag": "<tag_name>",
+  "parameters": {
+    "use_cache": false
+  }
+}' https://circleci.com/api/v2/project/github/<github_org>/<github_repo>/pipeline
+```
+3. Leave the password blank
+
+##### Upgrade Steps
+
+None required, default behavior will be to use the cache. To expose/enable this variable (recommended), add `use_cache` changes found in template in both `parameters` and `aliases` sections.
+
 #### [v0.3.2](https://circleci.com/orbs/registry/orb/elementaryrobotics/atom?version=0.3.2)
 
 ##### New Features

--- a/.circleci/atom.yml
+++ b/.circleci/atom.yml
@@ -304,10 +304,17 @@ commands:
   # Prepare the machine for buildx based builds
   enable_buildx:
     description: "Prepare the CircleCI machine for using buildx"
+    parameters:
+      buildkit_version:
+        type: string
+        default: v0.8.3
     steps:
       - run:
-          name: Switch to the multi-arch builder
-          command: docker buildx ls | grep "build-buildx" || docker buildx create --use --name build-buildx
+          name: Create builder with buildkit << parameters.buildkit_version >>
+          command: docker buildx ls | grep "build-<< parameters.buildkit_version >>" || docker buildx create --name build-<< parameters.buildkit_version >> --driver docker-container --driver-opt image=moby/buildkit:<< parameters.buildkit_version >>,network=host
+      - run:
+          name: Set builder
+          command: docker buildx use --default build-<< parameters.buildkit_version >>
       - run:
           name: Start up buildx and inspect
           command: docker buildx inspect --bootstrap

--- a/.circleci/atom.yml
+++ b/.circleci/atom.yml
@@ -33,6 +33,9 @@ aliases:
       use_git_lfs:
         type: boolean
         default: false
+      use_cache:
+        type: boolean
+        default: true
       cache_repo:
         type: string
       cache_tag:
@@ -50,6 +53,7 @@ aliases:
       build_args: << parameters.build_args >>
       no_output_timeout: << parameters.no_output_timeout >>
       use_git_lfs: << parameters.use_git_lfs >>
+      use_cache: << parameters.use_cache >>
       cache_repo: << parameters.cache_repo >>
       cache_tag: << parameters.cache_tag >>
 
@@ -335,14 +339,27 @@ commands:
       atom_base_arg:
         type: string
     steps:
+      - when:
+          condition: << parameters.use_cache >>
+          steps:
+            - run:
+                name: Set Input Cache
+                command: echo 'export INPUT_CACHE_ARGS="--cache-from=type=registry,ref=<< parameters.cache_repo >>:<< parameters.cache_tag >>-$(arch)"' >> ${BASH_ENV}
+      - unless:
+          condition: << parameters.use_cache >>
+          steps:
+            - run:
+                name: Skip Input Cache
+                command: echo 'export INPUT_CACHE_ARGS=""' >> ${BASH_ENV}
       - run:
           name: "Build Dockerfile << parameters.file >> stage << parameters.stage >>"
           working_directory: << parameters.working_directory >>
           command: >-
+            set -x;
             docker buildx build
             --progress plain
             --load
-            --cache-from=type=registry,ref=<< parameters.cache_repo >>:<< parameters.cache_tag >>-$(arch)
+            ${INPUT_CACHE_ARGS}
             --cache-to=type=registry,ref=<< parameters.cache_repo >>:<< parameters.cache_tag >>-$(arch),mode=max
             --label "com.elementaryrobotics.tag=${CIRCLE_TAG}"
             --label "com.elementaryrobotics.branch=${CIRCLE_BRANCH}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,11 @@ parameters:
     type: string
     default: ${HEROKU_APP_NAME}
 
+  # Build cache
+  use_cache:
+    type: boolean
+    default: true
+
 
 #
 # Section for setting repeatedly used yaml anchors/aliases
@@ -159,7 +164,7 @@ aliases:
 version: 2.1
 
 orbs:
-  atom:  elementaryrobotics/atom@0.3.0
+  atom:  elementaryrobotics/atom@0.3.3
 
 commands:
 
@@ -209,6 +214,7 @@ commands:
           # build cache
           cache_repo: << pipeline.parameters.dockerhub_org >>/<< pipeline.parameters.atom_repo_name >>
           cache_tag: cache<< parameters.atom_type >>
+          use_cache: << pipeline.parameters.use_cache >>
 
       # Tag and push nucleus image
       - atom/push_image:

--- a/.circleci/templates/config_basic.yml
+++ b/.circleci/templates/config_basic.yml
@@ -9,6 +9,7 @@ aliases:
       cache_repo: << pipeline.parameters.dockerhub_repo >>
       atom_tag: << pipeline.parameters.atom_tag >>
       atom_type: << pipeline.parameters.atom_type >>
+      use_cache: << pipeline.parameters.use_cache >>
   - &test_args
       test_image: << pipeline.parameters.dockerhub_repo >>
       atom_tag: << pipeline.parameters.atom_tag >>
@@ -32,6 +33,9 @@ parameters:
   atom_type:
     type: string
     default: #TODO: add in atom type from ["", "-cv", "-cuda", "-vnc"]
+  use_cache:
+    type: boolean
+    default: true
 
 orbs:
   atom: elementaryrobotics/atom@0.3.1

--- a/.circleci/templates/config_prod_and_test.yml
+++ b/.circleci/templates/config_prod_and_test.yml
@@ -9,6 +9,7 @@ aliases:
       cache_repo: << pipeline.parameters.dockerhub_repo >>
       atom_tag: << pipeline.parameters.atom_tag >>
       atom_type: << pipeline.parameters.atom_type >>
+      use_cache: << pipeline.parameters.use_cache >>
   - &test_args
       test_image: << pipeline.parameters.dockerhub_repo >>
       atom_tag: << pipeline.parameters.atom_tag >>
@@ -32,6 +33,10 @@ parameters:
   atom_type:
     type: string
     default: #TODO: add in atom type from ["", "-cv", "-cuda", "-vnc"]
+  use_cache:
+    type: boolean
+    default: true
+
 
 orbs:
   atom: elementaryrobotics/atom@0.3.1


### PR DESCRIPTION
- Use the buildkit container driver to decouple buildkit version
from the installed version of Docker on the CircleCI images.
- Use/upgrade to buildkit v0.8.3 to attempt to fix missing layer
bug/issue