### PR TITLE
Feature/improve orb build

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -125,6 +125,12 @@ circleci orb publish promote elementaryrobotics/atom@dev:some-tag patch
 
 ### Release Notes
 
+#### [v0.3.4](https://circleci.com/orbs/registry/orb/elementaryrobotics/atom?version=0.3.4)
+
+##### New Features
+
+Significant build speed improvements. Can take large images built off of CUDA from 20m down to 1m by not loading the output image into docker and instead just pushing directly to Docker Hub.
+
 #### [v0.3.3](https://circleci.com/orbs/registry/orb/elementaryrobotics/atom?version=0.3.3)
 
 ##### New Features

--- a/.circleci/atom.yml
+++ b/.circleci/atom.yml
@@ -358,7 +358,7 @@ commands:
             set -x;
             docker buildx build
             --progress plain
-            --load
+            --push
             ${INPUT_CACHE_ARGS}
             --cache-to=type=registry,ref=<< parameters.cache_repo >>:<< parameters.cache_tag >>-$(arch),mode=max
             --label "com.elementaryrobotics.tag=${CIRCLE_TAG}"
@@ -476,9 +476,6 @@ jobs:
           << : *build_args_mapping
           target_tag: << parameters.target_tag >>
           stage: << parameters.stage >>
-      - push_image:
-          target_image: << parameters.target_image >>
-          target_tag: << parameters.target_tag >>
 
   build_element:
     parameters:
@@ -500,9 +497,6 @@ jobs:
           stage: << parameters.stage >>
           target_tag: << parameters.target_tag >>
           atom_base_arg: *atom_build_base_arg
-      - push_image:
-          target_image: << parameters.target_image >>
-          target_tag: << parameters.target_tag >>
 
   build_element_prod_and_test:
     parameters:
@@ -521,9 +515,6 @@ jobs:
           stage: prod
           target_tag: << parameters.target_tag >>-prod
           atom_base_arg: *atom_build_base_arg
-      - push_image:
-          target_image: << parameters.target_image >>
-          target_tag: << parameters.target_tag >>-prod
 
       # Build + push test
       - build_dockerfile:
@@ -531,9 +522,6 @@ jobs:
           stage: test
           target_tag: << parameters.target_tag >>-test
           atom_base_arg: *atom_build_base_arg
-      - push_image:
-          target_image: << parameters.target_image >>
-          target_tag: << parameters.target_tag >>-test
 
   test:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,7 @@ aliases:
 version: 2.1
 
 orbs:
-  atom:  elementaryrobotics/atom@0.3.3
+  atom:  elementaryrobotics/atom@0.3.4
 
 commands:
 
@@ -215,11 +215,6 @@ commands:
           cache_repo: << pipeline.parameters.dockerhub_org >>/<< pipeline.parameters.atom_repo_name >>
           cache_tag: cache<< parameters.atom_type >>
           use_cache: << pipeline.parameters.use_cache >>
-
-      # Tag and push nucleus image
-      - atom/push_image:
-          target_image: << pipeline.parameters.dockerhub_org >>/<< parameters.repo >>
-          target_tag: build-<< pipeline.number >><< parameters.atom_type >>
 
   test_atom:
     parameters:

--- a/.circleci/templates/config_basic.yml
+++ b/.circleci/templates/config_basic.yml
@@ -38,7 +38,7 @@ parameters:
     default: true
 
 orbs:
-  atom: elementaryrobotics/atom@0.3.1
+  atom: elementaryrobotics/atom@0.3.4
 
 workflows:
   version: 2

--- a/.circleci/templates/config_prod_and_test.yml
+++ b/.circleci/templates/config_prod_and_test.yml
@@ -39,7 +39,7 @@ parameters:
 
 
 orbs:
-  atom: elementaryrobotics/atom@0.3.1
+  atom: elementaryrobotics/atom@0.3.4
 
 workflows:
   version: 2


### PR DESCRIPTION
Shows significant speedup (20m on large Docker images) by not loading into the host docker driver and then pushing but pushing directly from `buildx`. 