### PR TITLE
Atom-cli: Fixed the atom-cli records command.

### DIFF
--- a/doc/source/includes/walkthrough.md
+++ b/doc/source/includes/walkthrough.md
@@ -373,12 +373,6 @@ $ docker exec -it atombot atom-cli
 > records cmdres atombot
 ```
 
-> <button class="copy-button" onclick='copyText(this, "records log")'>Copy</button> (CLI) See all log messages
-
-```shell_session
-> records log
-```
-
 > <button class="copy-button" onclick='copyText(this, "exit")'>Copy</button> (CLI) Exit CLI
 
 ```shell_session
@@ -425,8 +419,6 @@ Now that our atombot element is running, let's interact with it using `atom-cli`
     - Do `serialization arrow` to use Apache Arrow serialization
 - We can see the history of our commands by using the `records` command
     - `records cmdres atombot`
-- We can also see all of the logs that have been written so far
-    - `records log`
 - You can exit atom-cli by either
     - `exit`
     - CTRL+D

--- a/languages/python/atom/element.py
+++ b/languages/python/atom/element.py
@@ -641,10 +641,7 @@ class Element:
             element_name: Name of the element to generate the id for.
             stream_name: Name of element_name's stream to generate the id for.
         """
-        if element_name is None:
-            return stream_name
-        else:
-            return f"stream:{element_name}:{stream_name}"
+        return f"stream:{element_name}:{stream_name}"
 
     def _make_metric_id(self, element_name: str, m_type: str, *m_subtypes: str) -> str:
         """

--- a/utilities/atom-cli/atom-cli.py
+++ b/utilities/atom-cli/atom-cli.py
@@ -26,7 +26,7 @@ class AtomCLI:
         )
         self.session = PromptSession(style=self.style)
         self.print_atom_os_logo()
-        self.serialization = "msgpack"
+        self.serialization : ser.SerializationMethod = "msgpack"
         self.cmd_map = {
             "help": self.cmd_help,
             "list": self.cmd_list,
@@ -60,7 +60,6 @@ class AtomCLI:
                 Can filter records from the last N seconds or from certain elements.
 
                 Usage:
-                  records log [<last_N_seconds>] [<element>...]
                   records cmdres [<last_N_seconds>] <element>..."""
             ),
             "cmd_command": cleandoc(
@@ -221,9 +220,7 @@ class AtomCLI:
             start_time = "0"
             elements = set(args[1:])
 
-        if mode == "log":
-            records = self.mode_log(start_time, elements)
-        elif mode == "cmdres":
+        if mode == "cmdres":
             if not elements:
                 print(usage)
                 print(
@@ -240,30 +237,9 @@ class AtomCLI:
             print("No records.")
             return
         for record in records:
-            print(self.format_record(record))
+            print(self.format_record(record))    
 
-    def mode_log(self, start_time, elements):
-        """
-        Reads the logs from Atom's log stream.
-
-        Args:
-            start_time (str): The time from which to start reading logs.
-            elements (list): The elements on which to filter the logs for.
-        """
-        records = []
-        all_records = self.element.entry_read_since(
-            None, "log", start_time, serialization=None
-        )
-        for record in all_records:
-            if not elements or record["element"].decode() in elements:
-                record = {
-                    key: (value if isinstance(value, str) else value.decode())
-                    for key, value in record.items()
-                }  # Decode strings only which are required to
-                records.append(record)
-        return records
-
-    def mode_cmdres(self, start_time, elements):
+    def mode_cmdres(self, start_time : str, elements : "set[str]"):
         """
         Reads the command and response records from the provided elements.
         Args:
@@ -271,30 +247,40 @@ class AtomCLI:
             elements (list): The elements to get the command and response
                 records from.
         """
-        streams, records = [], []
+        streams, records, entries = {}, [], []
         for element in elements:
-            streams.append(self.element._make_response_id(element))
-            streams.append(self.element._make_command_id(element))
-        for stream in streams:
-            cur_records = self.element.entry_read_since(
-                None, stream, start_time, serialization=None
-            )
-            for record in cur_records:
-                for key, value in record.items():
+            streams[self.element._make_response_id(element)] = start_time
+            streams[self.element._make_command_id(element)] = start_time
+       
+        # Read data
+        stream_entries = self.element._rclient.xread(streams)
+        
+        # Deserialize
+        for key, msgs in stream_entries:
+            print("stream entry key:", key)
+            key = key.decode()
+            for uid, entry in msgs:
+                entry = self.element._decode_entry(entry)
+                serialization = self.element._get_serialization_method(
+                    entry, None, False)                        
+                entry = self.element._deserialize_entry(entry, method=serialization)
+                entry["id"] = uid.decode()
+                entries.append(entry)
+
+                for entry_key, entry_value in entry.items():
                     try:
-                        if not isinstance(value, str):
-                            value = value.decode()
+                        if not isinstance(entry_value, str):
+                            entry_value = entry_value.decode()
                     except Exception:
                         try:
-                            value = ser.deserialize(value, method=self.serialization)
+                            entry_value = ser.deserialize(entry_value, method=self.serialization)
                         except Exception:
                             pass
-
                     finally:
-                        record[key] = value
-                record["type"], record["element"] = stream.split(":")
-                records.append(record)
-        return sorted(records, key=lambda x: (x["id"], x["type"]))
+                        entry[entry_key] = entry_value                    
+                entry["type"], entry["element"] = str(key).split(":")
+                print("Final print:", entry["type"], entry["element"])
+        return sorted(entries, key=lambda x: (x["id"], x["type"]))
 
     def cmd_command(self, *args):
         usage = self.usage["cmd_command"]

--- a/utilities/atom-cli/atom-cli.py
+++ b/utilities/atom-cli/atom-cli.py
@@ -257,7 +257,6 @@ class AtomCLI:
 
         # Deserialize
         for key, msgs in stream_entries:
-            print("stream entry key:", key)
             key = key.decode()
             for uid, entry in msgs:
                 entry = self.element._decode_entry(entry)
@@ -282,7 +281,6 @@ class AtomCLI:
                     finally:
                         entry[entry_key] = entry_value
                 entry["type"], entry["element"] = str(key).split(":")
-                print("Final print:", entry["type"], entry["element"])
         return sorted(entries, key=lambda x: (x["id"], x["type"]))
 
     def cmd_command(self, *args):

--- a/utilities/atom-cli/atom-cli.py
+++ b/utilities/atom-cli/atom-cli.py
@@ -26,7 +26,7 @@ class AtomCLI:
         )
         self.session = PromptSession(style=self.style)
         self.print_atom_os_logo()
-        self.serialization : ser.SerializationMethod = "msgpack"
+        self.serialization: ser.SerializationMethod = "msgpack"
         self.cmd_map = {
             "help": self.cmd_help,
             "list": self.cmd_list,
@@ -237,9 +237,9 @@ class AtomCLI:
             print("No records.")
             return
         for record in records:
-            print(self.format_record(record))    
+            print(self.format_record(record))
 
-    def mode_cmdres(self, start_time : str, elements : "set[str]"):
+    def mode_cmdres(self, start_time: str, elements: "set[str]"):
         """
         Reads the command and response records from the provided elements.
         Args:
@@ -247,14 +247,14 @@ class AtomCLI:
             elements (list): The elements to get the command and response
                 records from.
         """
-        streams, records, entries = {}, [], []
+        streams, entries = {}, []
         for element in elements:
             streams[self.element._make_response_id(element)] = start_time
             streams[self.element._make_command_id(element)] = start_time
-       
+
         # Read data
         stream_entries = self.element._rclient.xread(streams)
-        
+
         # Deserialize
         for key, msgs in stream_entries:
             print("stream entry key:", key)
@@ -262,7 +262,8 @@ class AtomCLI:
             for uid, entry in msgs:
                 entry = self.element._decode_entry(entry)
                 serialization = self.element._get_serialization_method(
-                    entry, None, False)                        
+                    entry, None, False
+                )
                 entry = self.element._deserialize_entry(entry, method=serialization)
                 entry["id"] = uid.decode()
                 entries.append(entry)
@@ -273,11 +274,13 @@ class AtomCLI:
                             entry_value = entry_value.decode()
                     except Exception:
                         try:
-                            entry_value = ser.deserialize(entry_value, method=self.serialization)
+                            entry_value = ser.deserialize(
+                                entry_value, method=self.serialization
+                            )
                         except Exception:
                             pass
                     finally:
-                        entry[entry_key] = entry_value                    
+                        entry[entry_key] = entry_value
                 entry["type"], entry["element"] = str(key).split(":")
                 print("Final print:", entry["type"], entry["element"])
         return sorted(entries, key=lambda x: (x["id"], x["type"]))


### PR DESCRIPTION
	This commit fixes the atom-cli  records command for the cmdres subcommand and removes the records log subcommand.