### PR TITLE
Add ability to override element name on entry write

### DIFF
--- a/doc/source/includes/sdk-specification.md
+++ b/doc/source/includes/sdk-specification.md
@@ -165,6 +165,10 @@ my_element.entry_write("my_stream", field_data_map, maxlen=512)
 # A "ser" key will be added to the entry with the serialization method used to serialize ("none" if not serialized).
 field_data_map = {"hello": 0, "atom": ["a", "t", "o", "m"]}
 my_element.entry_write("my_stream", field_data_map, maxlen=512, serialization="msgpack")
+
+# It is also possible to write to a stream that belongs to an element other than the calling element. For example, "my_element"
+# can write to a stream associated with "another_element".
+my_element.entry_write("my_stream", field_data_map, element_name="another_element")
 ```
 
 Publish a piece of data to a stream.
@@ -175,6 +179,7 @@ Publish a piece of data to a stream.
 |-----------|------|-------------|
 | `name` | string | Stream name |
 | `data` | map | key:value pairs of data to publish |
+| `element_name` | string | Optional: name of element stream belongs to. Defaults to calling element |
 | `maxlen` | int | Maximum length of stream. Optional. Default 1024 |
 | `serialization` | string | Type of serialization to use when publishing the entry |
 

--- a/languages/python/atom/element.py
+++ b/languages/python/atom/element.py
@@ -2276,6 +2276,7 @@ class Element:
         self,
         stream_name: str,
         field_data_map: dict[str, Any],
+        element_name: str = None,
         maxlen: int = STREAM_LEN,
         serialization: Optional[atom_ser.SerializationMethod] = None,
         serialize: Optional[bool] = None,
@@ -2288,6 +2289,8 @@ class Element:
             stream_name: The stream to add the data to.
             field_data_map: Dict which creates the Entry. See messages. Entry
                 for more usage.
+            element_name: str name of element to make stream ID for, will
+                default to this element's name if not specified
             maxlen: The maximum number of data to keep in the stream.
             serialization: Method of serialization to use; defaults to None.
 
@@ -2327,11 +2330,16 @@ class Element:
             entry = Entry(ser_field_data_map)
             self.metrics_timing_end(metrics["serialize"], pipeline=pipeline)
 
+            # Assign default element name if not specified
+            element_name = element_name if element_name else self.name
+
             # Write Data
             self.metrics_timing_start(metrics["data"])
             _pipe = self._rpipeline_pool.get()
             _pipe.xadd(
-                self._make_stream_id(self.name, stream_name), vars(entry), maxlen=maxlen
+                self._make_stream_id(element_name, stream_name),
+                vars(entry),
+                maxlen=maxlen,
             )
             ret = _pipe.execute()
             _pipe = self._release_pipeline(_pipe)

--- a/languages/python/tests/test_atom.py
+++ b/languages/python/tests/test_atom.py
@@ -262,6 +262,9 @@ class TestAtom:
         entries = caller.entry_read_since(responder_name, "test_stream", last_id=0)
         assert len(entries) == 0
 
+        # clean up stream (necessary since it doesn't belong to a real element)
+        caller._rclient.unlink("stream:fake_element:test_stream")
+
     def test_add_entry_and_get_n_most_recent_legacy_serialize(self, caller, responder):
         """
         Adds 10 entries to the responder's stream with legacy serialization

--- a/languages/python/tests/test_atom.py
+++ b/languages/python/tests/test_atom.py
@@ -392,6 +392,20 @@ class TestAtom:
         assert "clean_me" not in responder.streams
         self._assert_cleaned_up(responder)
 
+    def test_clean_up_stream_element_name(self, caller, responder):
+        """
+        Ensures an element can clean up a stream with a different element
+        name.
+        """
+        responder, responder_name = responder
+        responder.entry_write("clean_me", {"data": 0}, element_name="fake")
+
+        # have responder element clean up stream with fake element name
+        responder.clean_up_stream("clean_me", element_name="fake")
+
+        stream_exists = responder._rclient.exists("stream:clean_me:fake")
+        assert not stream_exists
+
     def test_clean_up(self, responder):
         """
         Ensures that a responder can be removed from Redis

--- a/languages/python/tests/test_atom.py
+++ b/languages/python/tests/test_atom.py
@@ -241,6 +241,27 @@ class TestAtom:
         assert entries[0]["data"] == b"9"
         assert entries[-1]["data"] == b"5"
 
+    def test_add_entry_with_override_element_name(self, caller, responder):
+        """
+        Adds an entry to the responder stream with a fake element name and
+        makes sure that entry is on correct stream.
+        """
+        caller, caller_name = caller
+        responder, responder_name = responder
+
+        responder.entry_write(
+            "test_stream", {"data": "fake"}, element_name="fake_element"
+        )
+
+        # assert that entries are on override element stream
+        entries = caller.entry_read_since("fake_element", "test_stream", last_id=0)
+        assert len(entries) == 1
+        assert entries[0]["data"] == b"fake"
+
+        # assert that writing element stream is empty
+        entries = caller.entry_read_since(responder_name, "test_stream", last_id=0)
+        assert len(entries) == 0
+
     def test_add_entry_and_get_n_most_recent_legacy_serialize(self, caller, responder):
         """
         Adds 10 entries to the responder's stream with legacy serialization


### PR DESCRIPTION
Adds new parameter to `entry_write` which allows for overriding the stream's element name. Defaults to the calling element name if unspecified.