### PR TITLE
metrics: drop default retention down to 10m

### DIFF
--- a/languages/python/atom/config.py
+++ b/languages/python/atom/config.py
@@ -46,15 +46,8 @@ METRICS_LANGUAGE_LABEL = "language"
 METRICS_LEVEL_LABEL = "level"
 METRICS_AGGREGATION_LABEL = "agg"
 METRICS_AGGREGATION_TYPE_LABEL = "agg_type"
-# Metrics default retention -- 1 hour of raw data
-METRICS_DEFAULT_RETENTION = 3600000
-# Metrics default aggregation rules
-METRICS_DEFAULT_AGG_TIMING = [
-    # Keep data in 10m buckets for 3 days
-    (600000, 259200000),
-    # Then keep data in 1h buckets for 30 days
-    (3600000, 2592000000),
-]
+# Metrics default retention -- 10 minutes of raw data
+METRICS_DEFAULT_RETENTION = 600000
 
 # Queue metrics
 METRICS_QUEUE_TYPE = "queue"

--- a/languages/python/atom/element.py
+++ b/languages/python/atom/element.py
@@ -42,7 +42,6 @@ from atom.config import (
     METRICS_AGGREGATION_LABEL,
     METRICS_AGGREGATION_TYPE_LABEL,
     METRICS_ATOM_VERSION_LABEL,
-    METRICS_DEFAULT_AGG_TIMING,
     METRICS_DEFAULT_RETENTION,
     METRICS_DEVICE_LABEL,
     METRICS_ELEMENT_LABEL,
@@ -4215,7 +4214,7 @@ class Element:
         *m_subtypes: str,
         retention: int = METRICS_DEFAULT_RETENTION,
         labels: Optional[dict] = None,
-        agg_timing: list[tuple[int, int]] = METRICS_DEFAULT_AGG_TIMING,
+        agg_timing: Optional[list[tuple[int, int]]] = None,
         agg_types: Optional[list[str]] = None,
         duplicate_policy: DuplicatePolicy = "last",
     ) -> Optional[str]:
@@ -4293,7 +4292,7 @@ class Element:
         #   over the time buckets and apply the aggregation types requested
         _rules = {}
 
-        if self._metrics_use_aggregation:
+        if self._metrics_use_aggregation and agg_timing is not None:
             for agg in agg_types:
                 for timing in agg_timing:
                     _rule_key = self._make_metric_id(


### PR DESCRIPTION
- Reduces metrics max retention to 10m to reduce overall memory hit for metrics
- Initializes default timing aggregation to None. This shouldn't have much effect as aggregation was already off by default, but was mainly good cleanup