### PR TITLE
Ers 617/remove click and through

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,13 +220,16 @@ commands:
         type: string
       stage:
         type: string
+      tag_additional:
+        type: string
+        default: ""
     steps:
 
       # Build nucleus
       - atom/build_dockerfile:
           stage: << parameters.stage >>
           target_image: << pipeline.parameters.dockerhub_org >>/<< parameters.repo >>
-          target_tag: build-<< pipeline.number >><< parameters.atom_type >>
+          target_tag: build-<< pipeline.number >><< parameters.atom_type >><< parameters.tag_additional >>
           build_args: >-
             --build-arg STOCK_IMAGE=<< parameters.stock_image_repo >>:<< parameters.stock_image_tag >>
             --build-arg ATOM_BASE=<< parameters.base >>
@@ -326,6 +329,7 @@ jobs:
           << : *build_atom_shared_mapping
           repo: << pipeline.parameters.atom_repo_name >>
           stage: test
+          tag_additional: -test
 
   test-atom:
     parameters:
@@ -339,7 +343,7 @@ jobs:
       - test_atom:
           atom_type: << parameters.atom_type >>
           nucleus_under_test: << pipeline.parameters.dockerhub_org >>/<< pipeline.parameters.nucleus_repo_name >>:build-<< pipeline.number >>-$(arch)
-          atom_under_test: << pipeline.parameters.dockerhub_org >>/<< pipeline.parameters.atom_repo_name >>:build-<< pipeline.number >><< parameters.atom_type >>-$(arch)
+          atom_under_test: << pipeline.parameters.dockerhub_org >>/<< pipeline.parameters.atom_repo_name >>:build-<< pipeline.number >><< parameters.atom_type >>-test-$(arch)
           compose_file: .circleci/docker-compose-circle.yml
           compose_container_name: test_atom
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -144,8 +144,17 @@ RUN cd /atom/third-party/redis && make -j8 && make PREFIX=/usr/local install
 RUN apt-get install -y ca-certificates
 ADD ./third-party/RedisTimeSeries /atom/third-party/RedisTimeSeries
 WORKDIR /atom/third-party/RedisTimeSeries
-RUN python3 system-setup.py
-RUN make build MK.pyver=3
+
+# Need to make a separate virtualenv for the build since it installs
+# a bunch of python cruft we don't need in our production env. Make the
+# env, use it for the build, and then re-source the original
+# environment.
+RUN python3 -m venv env && \
+  . env/bin/activate && \
+  python3 system-setup.py && \
+  make build MK.pyver=3 && \
+  . /opt/venv/bin/activate && \
+  rm -rf env
 
 #
 # Finish up


### PR DESCRIPTION
Working to remove some non-essential packages and found a few improvements in the build which do so:

1. We were shipping the `test` stage of the Dockerfile instead of the `atom` stage without realizing it due to both images pushing to the same dockerhub tag. This has been amended and the test image now adds `-test` into the tag string and it's been validated we're no longer shipping test dependencies in the release builds. This removed `npm` which removed all of the NPM source/deps.

2. We are building RedisTimeSeries from source. Their build process requires python, and installs a few packages that are build-only and not needed at runtime. The build for this dependency has been moved to a virtualenv so that it no longer impacts the production build environment