### PR TITLE
Client can optionally pass Redis stream id to entry_write

### DIFF
--- a/languages/python/atom/element.py
+++ b/languages/python/atom/element.py
@@ -2280,6 +2280,7 @@ class Element:
         maxlen: int = STREAM_LEN,
         serialization: Optional[atom_ser.SerializationMethod] = None,
         serialize: Optional[bool] = None,
+        id: str = "*",
     ) -> str:
         """
         Creates element's stream if it does not exist. Adds the fields and data
@@ -2293,6 +2294,7 @@ class Element:
                 default to this element's name if not specified
             maxlen: The maximum number of data to keep in the stream.
             serialization: Method of serialization to use; defaults to None.
+            id: Let client specify own stream id, else Redis generates it.
 
             Deprecated:
             serialize: Whether or not to serialize the entry using msgpack;
@@ -2341,6 +2343,7 @@ class Element:
             _pipe.xadd(
                 self._make_stream_id(element_name, stream_name),
                 vars(entry),
+                id=id,
                 maxlen=maxlen,
             )
             ret = _pipe.execute()


### PR DESCRIPTION
## Change description

https://elementary.atlassian.net/browse/ERS-1268

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

https://elementary.atlassian.net/browse/ERS-1268

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
