### PR TITLE
ERS-1357 bump base Ubuntu to resolve CVE-2021-3711 and CVE-2021-33910

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ aliases:
 
   # Base image versions and files
   - &atom_base_image_repo ubuntu
-  - &atom_base_image_tag bionic-20210416
+  - &atom_base_image_tag bionic-20210827
   - &atom_cuda_amd64_image_repo nvcr.io/nvidia/cuda
   - &atom_cuda_amd64_image_tag 10.2-cudnn8-devel-ubuntu18.04
   - &atom_cuda_aarch64_image_repo nvcr.io/nvidia/l4t-base

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # ALL ARGS TO BE USED IN **ANY** FROM MUST OCCUR BEFORE THE **FIRST** FROM
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 #
-ARG STOCK_IMAGE=ubuntu:focal-20210416
+ARG STOCK_IMAGE=ubuntu:focal-20210827
 ARG ATOM_BASE=atom-base
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # ALL ARGS TO BE USED IN **ANY** FROM MUST OCCUR BEFORE THE **FIRST** FROM
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 #
-ARG STOCK_IMAGE=ubuntu:focal-20210827
+ARG STOCK_IMAGE=ubuntu:bionic-20210827
 ARG ATOM_BASE=atom-base
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## Change description

ERS-1357 bump base Ubuntu to resolve CVE-2021-3711 and CVE-2021-33910

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
