### PR TITLE
ERS-1357 upgrade packages released since last Ubuntu image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ARG PYTHON_VERSION=3.8.10
 # System-level installs
 #
 
-RUN apt-get update \
+RUN apt-get update && apt-get -y upgrade \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       apt-utils \
       git \
@@ -172,7 +172,7 @@ WORKDIR /atom
 FROM atom-base as atom-base-cv-build
 
 # Install pre-requisites
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+RUN apt-get update && apt-get -y upgrade && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     zlib1g-dev \
     libjpeg-turbo8-dev \
     libpng-dev \
@@ -392,7 +392,7 @@ ENV ATOM_LOG_FILE_SIZE 2000
 ENV PYTHONUNBUFFERED=TRUE
 
 # Install python
-RUN apt-get update -y \
+RUN apt-get update -y && apt-get -y upgrade \
    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends apt-utils \
    curl \
    libatomic1
@@ -471,7 +471,7 @@ FROM atom as test
 #
 
 # Install dependencies
-RUN apt-get update \
+RUN apt-get update && apt-get -y upgrade \
    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
    libgtest-dev \
    cmake \


### PR DESCRIPTION
## Change description

ERS-1357 upgrade packages released since last Ubuntu image

This should also ensure that packages are updated for each new Atom build as opposed to us manually incrementing the Ubuntu base.

## Type of change
- [] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
