### PR TITLE
ERS-1358 upgrade grafana and grafana-redis-datasource

### DIFF
--- a/metrics/Dockerfile
+++ b/metrics/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/grafana:7.5.7
+FROM grafana/grafana:8.1.5
 
 # Use root user -- easier/better able to store configs locally.
 # THIS SHOULD NOT BE USED FOR NON-LOCAL SETUPS
@@ -16,7 +16,7 @@ ENV REDIS_CLI_BIN /usr/bin/redis-cli
 ENV PYTHONUNBUFFERED=TRUE
 
 # Install our requirements
-RUN apk update && apk add alpine-sdk git go npm python2 python3 py-pip redis
+RUN apk update && apk upgrade && apk add alpine-sdk git go npm python2 python3 py-pip redis
 
 # Install Mage
 RUN mkdir -p /root/go/bin && git clone https://github.com/magefile/mage && cd mage && go run bootstrap.go


### PR DESCRIPTION
## Change description

ERS-1358 upgrade grafana and grafana-redis-datasource used in metrics

This will upgrade grafana from 7.5.7 to 8.1.3 and will upgrade grafana-redis-datasource plugin from 1.4.0 to 1.5.0 to resolve some identified vulnerabilities.

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

## Checklists

### Development

- [x] Lint rules pass locally
- [] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
